### PR TITLE
docs: update recommended tokens in spec

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -335,9 +335,9 @@ This section provides practical guidelines and common pitfalls. These act as gua
 
 The following names are commonly used across design systems. They are not required but are provided as guidance for consistency.
 
-**Typography:** `headline-display`, `headline-lg`, `headline-md`, `body-lg`, `body-md`, `body-sm`, `label-lg`, `label-md`, `label-sm`
+**Colors:** `primary`, `secondary`, `tertiary`, `neutral`, `surface`, `on-surface`, `error`
 
-**Spacing:** `unit`, `gutter`, `margin`, `xs`, `sm`, `md`, `lg`, `xl`
+**Typography:** `headline-display`, `headline-lg`, `headline-md`, `body-lg`, `body-md`, `body-sm`, `label-lg`, `label-md`, `label-sm`
 
 **Rounded:** `none`, `sm`, `md`, `lg`, `xl`, `full`
 

--- a/packages/cli/src/linter/spec-config.yaml
+++ b/packages/cli/src/linter/spec-config.yaml
@@ -70,6 +70,14 @@ color_roles:
   - neutral
 
 recommended_tokens:
+  colors:
+    - primary
+    - secondary
+    - tertiary
+    - neutral
+    - surface
+    - on-surface
+    - error
   typography:
     - headline-display
     - headline-lg
@@ -80,15 +88,6 @@ recommended_tokens:
     - label-lg
     - label-md
     - label-sm
-  spacing:
-    - unit
-    - gutter
-    - margin
-    - xs
-    - sm
-    - md
-    - lg
-    - xl
   rounded:
     - none
     - sm


### PR DESCRIPTION
This PR updates the recommended token names in the `DESIGN.md` specification and the associated linter configuration. The goal is to align with a "foundation, not prescription" philosophy by removing overly specific spacing recommendations and adding high-level color roles that provide common ground for design systems.

## Changes

### `packages/cli/src/linter/spec-config.yaml`
- **Removed:** Recommended spacing tokens (`spacing-xs`, `spacing-s`, etc.) to avoid over-prescribing layout details.
- **Added:** Recommended color tokens based on common roles (`primary`, `secondary`, `tertiary`, `neutral`, `surface`, `on-surface`, `error`) to encourage consistent color semantics across projects.

### `docs/spec.md`
- Updated the "Recommended Token Names" section to reflect the removal of spacing tokens and the addition of the new color roles, keeping the documentation in sync with the linter's source of truth.