### PR TITLE
fix: support transparent hex colors (#14)

### DIFF
--- a/.agents/skills/design-md-show/SKILL.md
+++ b/.agents/skills/design-md-show/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: design-md-show
+description: Automatically triggers the visual preview after creating or updating a DESIGN.md file using the 'show' command.
+---
+
+# Design System Visualization Rule
+
+Whenever you create, modify, or update the `DESIGN.md` file or its contents in this project, you must strictly follow these steps:
+
+1. Update the YAML design tokens or Markdown rationale in `DESIGN.md` based on the specific vibe or requirement requested.
+2. Automatically execute the visualization command in the terminal to open the generated design-board preview:
+   ```bash
+   npx @google/design.md show DESIGN.md
+   ```
+   *(If you are developing locally inside the design.md repository itself, use: `bun run packages/cli/src/index.ts show DESIGN.md`)*
+3. Confirm that the visual preview (an HTML file) has been successfully generated and opened.
+4. Briefly summarize the changes made to the design tokens and inform the user that the preview is ready to view.
+
+This visual feedback loop bridges the gap between structured machine-readable code (YAML/JSON) and human-readable interfaces, reducing hallucinations and making it much easier to iterate on design choices.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Or run directly:
 npx @google/design.md lint DESIGN.md
 ```
 
-All commands accept a file path or `-` for stdin. Output defaults to JSON.
+Most commands accept a file path or `-` for stdin. Output defaults to JSON.
 
 ### `lint`
 
@@ -233,6 +233,25 @@ npx @google/design.md export --format dtcg DESIGN.md > tokens.json
 |:-------|:-----|:--------|:------------|
 | `file` | positional | required | Path to DESIGN.md (or `-` for stdin) |
 | `--format` | `tailwind` \| `dtcg` | required | Output format |
+
+### `show`
+
+Generate an offline HTML token-board preview from DESIGN.md structured tokens.
+
+```bash
+npx @google/design.md show DESIGN.md
+npx @google/design.md show DESIGN.md --open false
+npx @google/design.md show DESIGN.md --output ./design-preview.html
+```
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `file` | positional | required | Path to DESIGN.md (stdin `-` is not supported in v1) |
+| `--output` | `string` | none | Optional output path for generated HTML |
+| `--open` | `true` \| `false` | `true` | Whether to open the generated HTML in the browser |
+| `--format` | `json` \| `markdown` | `json` | Output format |
+
+Exit code is `1` when lint errors are present. The preview is still generated when possible.
 
 ### `spec`
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,34 +13,40 @@
     },
     "packages/cli": {
       "name": "@google/design.md",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "design.md": "./dist/index.js",
-        "designmd": "./dist/index.js",
       },
       "dependencies": {
+        "@json-render/core": "^0.16.0",
+        "@json-render/ink": "^0.16.0",
+        "citty": "^0.1.6",
+        "ink": "^7.0.0",
+        "mdast": "^3.0.0",
+        "react": "^19.2.5",
+        "remark-frontmatter": "^5.0.0",
+        "remark-mdx": "^3.1.1",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0",
+        "yaml": "^2.7.1",
         "zod": "^3.24.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/mdast": "^4.0.4",
         "@types/node": "^20.11.24",
+        "@types/react": "^19.2.14",
         "bun-types": "^1.3.12",
-        "citty": "^0.1.6",
-        "mdast": "^3.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-mdx": "^3.1.1",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
         "tailwindcss": "3",
         "typescript": "^5.7.3",
-        "unified": "^11.0.5",
-        "unist-util-visit": "^5.1.0",
-        "yaml": "^2.7.1",
       },
     },
   },
   "packages": {
+    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@google/design.md": ["@google/design.md@workspace:packages/cli"],
@@ -52,6 +58,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@json-render/core": ["@json-render/core@0.16.0", "", { "dependencies": { "zod": "^4.3.6" } }, "sha512-qQp8BB/3pWYapTGXBDSBMXRCdrC05VJPLL3drXMPX/QbUB3nuvtyXUGmAZFUz8eLUy7JImODvb3GNIq38dGzhQ=="],
+
+    "@json-render/ink": ["@json-render/ink@0.16.0", "", { "dependencies": { "@json-render/core": "0.16.0", "marked": "^17.0.0" }, "peerDependencies": { "ink": "^6.0.0", "react": "^19.0.0" } }, "sha512-oJ/MbW0zLkv3i6MSZVk8QiI6mbyvtA0XZpJEuJBTCf1yjMMdxN16Mz/uW/5AV9FMOBjZXohQPONLMxvSxil6Bg=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -87,17 +97,27 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
+
+    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
@@ -111,6 +131,8 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
@@ -123,11 +145,23 @@
 
     "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
+    "cli-boxes": ["cli-boxes@4.0.1", "", {}, "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw=="],
+
+    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
+
+    "cli-truncate": ["cli-truncate@6.0.0", "", { "dependencies": { "slice-ansi": "^9.0.0", "string-width": "^8.2.0" } }, "sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA=="],
+
+    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
+
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
+    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
+
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -141,9 +175,13 @@
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
-    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+    "es-toolkit": ["es-toolkit@1.46.0", "", {}, "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
@@ -167,9 +205,15 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "ink": ["ink@7.0.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.3.0", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.3", "auto-bind": "^5.0.1", "chalk": "^5.6.2", "cli-boxes": "^4.0.1", "cli-cursor": "^4.0.0", "cli-truncate": "^6.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.45.1", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^9.0.0", "stack-utils": "^2.0.6", "string-width": "^8.2.0", "terminal-size": "^4.0.1", "type-fest": "^5.5.0", "widest-line": "^6.0.0", "wrap-ansi": "^10.0.0", "ws": "^8.20.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.2.0", "react": ">=19.2.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-o6LAC268PLawlGVYrXTyaTfke4VtJftEheuwbgkQf7yvSXyWp1nRwBbAyKEkWXFZZsW/la5wrMuNbuBvZK2C1w=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -183,9 +227,13 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -198,6 +246,8 @@
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
 
     "mdast": ["mdast@3.0.0", "", {}, "sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g=="],
 
@@ -281,6 +331,8 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
@@ -293,7 +345,11 @@
 
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
 
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
+    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
@@ -321,6 +377,10 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
+
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
@@ -335,19 +395,37 @@
 
     "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
+    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "slice-ansi": ["slice-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
+
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
+
+    "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -362,6 +440,8 @@
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
     "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
+
+    "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
@@ -385,7 +465,15 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
+    "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
+
+    "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -395,9 +483,13 @@
 
     "@google/design.md/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
+    "@json-render/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "mdast-util-frontmatter/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 

--- a/examples/atmospheric-glass/preview.html
+++ b/examples/atmospheric-glass/preview.html
@@ -1,0 +1,1189 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Atmospheric Glass - DESIGN.md Show</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&family=Noto+Serif:wght@400;700&display=swap');
+
+    :root {
+      --bg-dark: #242424;
+      --board-bg: #e2e2db;
+      --board-border: #7951ff;
+      --card-bg: #f5f5f0;
+      --text-main: #333333;
+      --text-muted: #888888;
+      --radius-xl: 1.5rem;
+      --radius-lg: 1rem;
+      --radius-md: 0.75rem;
+      --radius-sm: 0.5rem;
+      --radius-pill: 9999px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "Manrope", sans-serif;
+      color: var(--text-main);
+      background-color: var(--bg-dark);
+      background-image: radial-gradient(#3a3a3a 1px, transparent 0);
+      background-size: 20px 20px;
+      padding: 2rem 4rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .page-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      color: white;
+      padding: 0 1rem;
+    }
+
+    .page-title {
+      font-weight: 700;
+      font-size: 1.25rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    
+    .page-title svg {
+      width: 24px;
+      height: 24px;
+      fill: currentColor;
+    }
+
+    .page-actions {
+      display: flex;
+      gap: 0.5rem;
+      color: #999;
+    }
+
+    .page-actions svg {
+      width: 24px;
+      height: 24px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 2;
+    }
+
+    .board-container {
+      border: 4px solid var(--board-border);
+      border-radius: var(--radius-xl);
+      background: var(--board-bg);
+      padding: 1.5rem;
+      box-shadow: 0 24px 48px rgba(0,0,0,0.2);
+    }
+
+    .tabs {
+      display: flex;
+      gap: 1.5rem;
+      margin-bottom: 1.5rem;
+      border-bottom: 2px solid rgba(0,0,0,0.05);
+      padding-bottom: 0.5rem;
+    }
+
+    .tab-btn {
+      background: none;
+      border: none;
+      color: var(--text-muted);
+      font-family: "Manrope", sans-serif;
+      font-weight: 700;
+      font-size: 1rem;
+      cursor: pointer;
+      padding: 0.5rem 0.25rem;
+      border-bottom: 3px solid transparent;
+      margin-bottom: -0.5rem;
+      transition: color 0.2s, border-color 0.2s;
+    }
+
+    .tab-btn:hover {
+      color: var(--text-main);
+    }
+
+    .tab-btn.active {
+      color: var(--text-main);
+      border-bottom-color: var(--board-border);
+    }
+
+    .tab-content {
+      display: none;
+      animation: fadeIn 0.3s ease;
+    }
+
+    .tab-content.active {
+      display: block;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(5px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    /* Column layouts for Overview */
+    .grid-4 {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 1.5rem;
+      align-items: start;
+    }
+
+    .column {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    /* Masonry layout for inner tabs */
+    .masonry {
+      column-count: 4;
+      column-gap: 1.5rem;
+    }
+    .masonry > * {
+      break-inside: avoid;
+      margin-bottom: 1.5rem;
+    }
+    
+    .grid-auto {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 1.5rem;
+      align-items: start;
+    }
+
+    /* Cards */
+    .card {
+      background: var(--card-bg);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+      padding: 1.25rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    /* Color Card */
+    .color-card {
+      padding: 0;
+      gap: 0;
+    }
+    .color-main {
+      padding: 1.25rem;
+      display: flex;
+      justify-content: space-between;
+      font-weight: 700;
+      font-size: 0.9rem;
+      min-height: 120px;
+    }
+    .color-shades {
+      display: flex;
+      height: 36px;
+    }
+    .color-shades i {
+      flex: 1;
+      background: var(--shade);
+    }
+
+    /* Typography Card */
+    .type-header {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin-bottom: 2.5rem;
+    }
+    .type-sample {
+      margin: 0;
+      text-align: center;
+      font-size: 6.5rem;
+      line-height: 1;
+      color: #333;
+      padding-bottom: 1.5rem;
+    }
+
+    /* Dimension Rows */
+    .dim-row {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 0.5rem;
+      font-size: 0.85rem;
+      margin-bottom: 0.5rem;
+      align-items: center;
+    }
+    .dim-bar {
+      grid-column: 1 / -1;
+      height: 6px;
+      border-radius: var(--radius-pill);
+      background: rgba(0,0,0,0.05);
+      margin-bottom: 1rem;
+    }
+    .dim-bar i {
+      display: block;
+      height: 100%;
+      border-radius: var(--radius-pill);
+      background: #5d665b;
+      width: var(--width);
+    }
+    .rounded-chip {
+      height: 32px;
+      background: rgba(0,0,0,0.1);
+      border-radius: var(--radius);
+      margin-top: 0.25rem;
+    }
+
+    /* Components */
+    .component-prop {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.85rem;
+      padding: 0.35rem 0;
+      border-bottom: 1px solid rgba(0,0,0,0.05);
+    }
+    .component-prop:last-child {
+      border-bottom: none;
+    }
+    .component-prop strong {
+      color: var(--text-muted);
+      font-weight: 400;
+    }
+
+    .diagnostics {
+      margin-bottom: 1rem;
+      border-radius: var(--radius-md);
+      padding: 1rem;
+      background: #ffebee;
+      color: #c62828;
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 1200px) {
+      .grid { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (max-width: 768px) {
+      .grid { grid-template-columns: 1fr; }
+      body { padding: 1rem; }
+    }
+  </style>
+</head>
+<body>
+  <header class="page-header">
+    <div class="page-title">
+      <svg viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/></svg>
+      Atmospheric Glass
+    </div>
+    <div class="page-actions">
+      <svg viewBox="0 0 24 24"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon></svg>
+      <svg viewBox="0 0 24 24"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"></path></svg>
+      <svg viewBox="0 0 24 24"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h3a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2h-3"></path></svg>
+    </div>
+  </header>
+
+  <div class="board-container">
+    <div class="diagnostics">
+    <p style="margin:0 0 0.5rem;font-weight:bold;">Diagnostics: 0 errors, 43 warnings</p>
+    <ul style="margin:0;padding-left:1.5rem;"><li>[colors.surface] &#39;surface&#39; is defined but never referenced by any component.</li><li>[colors.surface-dim] &#39;surface-dim&#39; is defined but never referenced by any component.</li><li>[colors.surface-bright] &#39;surface-bright&#39; is defined but never referenced by any component.</li><li>[colors.surface-container-lowest] &#39;surface-container-lowest&#39; is defined but never referenced by any component.</li><li>[colors.surface-container-low] &#39;surface-container-low&#39; is defined but never referenced by any component.</li><li>[colors.surface-container] &#39;surface-container&#39; is defined but never referenced by any component.</li></ul>
+  </div>
+    
+    <nav class="tabs">
+      <button class="tab-btn active" onclick="showTab(event, 'tab-overview')">Overview</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-colors')">Colors (47)</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-typography')">Typography (6)</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-layout')">Layout (5)</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-shapes')">Shapes (6)</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-components')">Components (10)</button>
+    </nav>
+
+    <main class="board">
+      
+      <!-- OVERVIEW TAB -->
+      <div id="tab-overview" class="tab-content active">
+        <div class="grid-4">
+          <div class="column">
+            <article class="card color-card">
+      <div class="color-main" style="background-color: #0b1326; color: #ffffff;">
+        <span>background</span>
+        <span>#0B1326</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#03050a"></i><i style="--shade:#050911"></i><i style="--shade:#070c19"></i><i style="--shade:#091020"></i><i style="--shade:#0b1326"></i><i style="--shade:#3c4251"></i><i style="--shade:#6d717d"></i><i style="--shade:#9da1a8"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffb4ab; color: #000000;">
+        <span>error</span>
+        <span>#FFB4AB</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#402d2b"></i><i style="--shade:#73514d"></i><i style="--shade:#a6756f"></i><i style="--shade:#d99991"></i><i style="--shade:#ffb4ab"></i><i style="--shade:#ffc3bc"></i><i style="--shade:#ffd2cd"></i><i style="--shade:#ffe1dd"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #93000a; color: #ffffff;">
+        <span>error-container</span>
+        <span>#93000A</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#250003"></i><i style="--shade:#420005"></i><i style="--shade:#600007"></i><i style="--shade:#7d0009"></i><i style="--shade:#93000a"></i><i style="--shade:#a9333b"></i><i style="--shade:#be666c"></i><i style="--shade:#d4999d"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #283044; color: #ffffff;">
+        <span>inverse-on-surface</span>
+        <span>#283044</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0a0c11"></i><i style="--shade:#12161f"></i><i style="--shade:#1a1f2c"></i><i style="--shade:#22293a"></i><i style="--shade:#283044"></i><i style="--shade:#535969"></i><i style="--shade:#7e838f"></i><i style="--shade:#a9acb4"></i>
+      </div>
+    </article>
+          </div>
+          <div class="column">
+            <article class="card">
+        <div class="type-header">
+          <span>body-lg</span>
+          <span>Inter</span>
+        </div>
+        <p class="type-sample" style="font-family:Inter;font-size: 6.5rem;font-weight:400">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>body-md</span>
+          <span>Inter</span>
+        </div>
+        <p class="type-sample" style="font-family:Inter;font-size: 6.5rem;font-weight:400">Aa</p>
+      </article>
+          </div>
+          <div class="column">
+            <div class="card">
+              <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">Spacing</h3>
+              <div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">card-gap</strong>
+          <span style="color:var(--text-muted);">16px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:35.2px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">container-padding</strong>
+          <span style="color:var(--text-muted);">24px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:52.800000000000004px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">glass-padding</strong>
+          <span style="color:var(--text-muted);">20px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:44px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">section-margin</strong>
+          <span style="color:var(--text-muted);">40px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:88px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">unit</strong>
+          <span style="color:var(--text-muted);">8px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:17.6px"></i></div>
+      </div>
+            </div>
+            <article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-ghost</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>rgba(255, 255, 255, 0.05)</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>1.5rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#ffffff</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Inter 12px/16px (600)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-primary</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#ffffff</span>
+      </div><div class="component-prop">
+        <strong>height</strong>
+        <span>48px</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>0 24px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>1.5rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#2f3131</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Inter 12px/16px (600)</span>
+      </div>
+      </div>
+    </article>
+          </div>
+          <div class="column">
+            <div class="card">
+              <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">Rounded</h3>
+              <div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">DEFAULT</strong>
+          <span style="color:var(--text-muted);">0.5rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.5rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">full</strong>
+          <span style="color:var(--text-muted);">9999px</span>
+        </div>
+        <div class="rounded-chip" style="--radius:9999px"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">lg</strong>
+          <span style="color:var(--text-muted);">1rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:1rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">md</strong>
+          <span style="color:var(--text-muted);">0.75rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.75rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">sm</strong>
+          <span style="color:var(--text-muted);">0.25rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.25rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">xl</strong>
+          <span style="color:var(--text-muted);">1.5rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:1.5rem"></div>
+      </div>
+            </div>
+            <article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-primary-hover</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#c6c6c7</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">glass-card-elevated</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>rgba(255, 255, 255, 0.2)</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>20px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>1.5rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#ffffff</span>
+      </div>
+      </div>
+    </article>
+          </div>
+        </div>
+      </div>
+
+      <!-- COLORS TAB -->
+      <div id="tab-colors" class="tab-content">
+        <div class="grid-auto">
+          <article class="card color-card">
+      <div class="color-main" style="background-color: #0b1326; color: #ffffff;">
+        <span>background</span>
+        <span>#0B1326</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#03050a"></i><i style="--shade:#050911"></i><i style="--shade:#070c19"></i><i style="--shade:#091020"></i><i style="--shade:#0b1326"></i><i style="--shade:#3c4251"></i><i style="--shade:#6d717d"></i><i style="--shade:#9da1a8"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffb4ab; color: #000000;">
+        <span>error</span>
+        <span>#FFB4AB</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#402d2b"></i><i style="--shade:#73514d"></i><i style="--shade:#a6756f"></i><i style="--shade:#d99991"></i><i style="--shade:#ffb4ab"></i><i style="--shade:#ffc3bc"></i><i style="--shade:#ffd2cd"></i><i style="--shade:#ffe1dd"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #93000a; color: #ffffff;">
+        <span>error-container</span>
+        <span>#93000A</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#250003"></i><i style="--shade:#420005"></i><i style="--shade:#600007"></i><i style="--shade:#7d0009"></i><i style="--shade:#93000a"></i><i style="--shade:#a9333b"></i><i style="--shade:#be666c"></i><i style="--shade:#d4999d"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #283044; color: #ffffff;">
+        <span>inverse-on-surface</span>
+        <span>#283044</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0a0c11"></i><i style="--shade:#12161f"></i><i style="--shade:#1a1f2c"></i><i style="--shade:#22293a"></i><i style="--shade:#283044"></i><i style="--shade:#535969"></i><i style="--shade:#7e838f"></i><i style="--shade:#a9acb4"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #5d5f5f; color: #ffffff;">
+        <span>inverse-primary</span>
+        <span>#5D5F5F</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#171818"></i><i style="--shade:#2a2b2b"></i><i style="--shade:#3c3e3e"></i><i style="--shade:#4f5151"></i><i style="--shade:#5d5f5f"></i><i style="--shade:#7d7f7f"></i><i style="--shade:#9e9f9f"></i><i style="--shade:#bebfbf"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #dae2fd; color: #000000;">
+        <span>inverse-surface</span>
+        <span>#DAE2FD</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#37393f"></i><i style="--shade:#626672"></i><i style="--shade:#8e93a4"></i><i style="--shade:#b9c0d7"></i><i style="--shade:#dae2fd"></i><i style="--shade:#e1e8fd"></i><i style="--shade:#e9eefe"></i><i style="--shade:#f0f3fe"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #dae2fd; color: #000000;">
+        <span>on-background</span>
+        <span>#DAE2FD</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#37393f"></i><i style="--shade:#626672"></i><i style="--shade:#8e93a4"></i><i style="--shade:#b9c0d7"></i><i style="--shade:#dae2fd"></i><i style="--shade:#e1e8fd"></i><i style="--shade:#e9eefe"></i><i style="--shade:#f0f3fe"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #690005; color: #ffffff;">
+        <span>on-error</span>
+        <span>#690005</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#1a0001"></i><i style="--shade:#2f0002"></i><i style="--shade:#440003"></i><i style="--shade:#590004"></i><i style="--shade:#690005"></i><i style="--shade:#873337"></i><i style="--shade:#a56669"></i><i style="--shade:#c3999b"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffdad6; color: #000000;">
+        <span>on-error-container</span>
+        <span>#FFDAD6</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#403736"></i><i style="--shade:#736260"></i><i style="--shade:#a68e8b"></i><i style="--shade:#d9b9b6"></i><i style="--shade:#ffdad6"></i><i style="--shade:#ffe1de"></i><i style="--shade:#ffe9e6"></i><i style="--shade:#fff0ef"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #2f3131; color: #ffffff;">
+        <span>on-primary</span>
+        <span>#2F3131</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0c0c0c"></i><i style="--shade:#151616"></i><i style="--shade:#1f2020"></i><i style="--shade:#282a2a"></i><i style="--shade:#2f3131"></i><i style="--shade:#595a5a"></i><i style="--shade:#828383"></i><i style="--shade:#acadad"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #636565; color: #ffffff;">
+        <span>on-primary-container</span>
+        <span>#636565</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#191919"></i><i style="--shade:#2d2d2d"></i><i style="--shade:#404242"></i><i style="--shade:#545656"></i><i style="--shade:#636565"></i><i style="--shade:#828484"></i><i style="--shade:#a1a3a3"></i><i style="--shade:#c1c1c1"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #1a1c1c; color: #ffffff;">
+        <span>on-primary-fixed</span>
+        <span>#1A1C1C</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#070707"></i><i style="--shade:#0c0d0d"></i><i style="--shade:#111212"></i><i style="--shade:#161818"></i><i style="--shade:#1a1c1c"></i><i style="--shade:#484949"></i><i style="--shade:#767777"></i><i style="--shade:#a3a4a4"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #454747; color: #ffffff;">
+        <span>on-primary-fixed-variant</span>
+        <span>#454747</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#111212"></i><i style="--shade:#1f2020"></i><i style="--shade:#2d2e2e"></i><i style="--shade:#3b3c3c"></i><i style="--shade:#454747"></i><i style="--shade:#6a6c6c"></i><i style="--shade:#8f9191"></i><i style="--shade:#b5b5b5"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #14324e; color: #ffffff;">
+        <span>on-secondary</span>
+        <span>#14324E</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#050d14"></i><i style="--shade:#091623"></i><i style="--shade:#0d2133"></i><i style="--shade:#112b42"></i><i style="--shade:#14324e"></i><i style="--shade:#435b71"></i><i style="--shade:#728495"></i><i style="--shade:#a1adb8"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #9fbbdd; color: #000000;">
+        <span>on-secondary-container</span>
+        <span>#9FBBDD</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#282f37"></i><i style="--shade:#485463"></i><i style="--shade:#677a90"></i><i style="--shade:#879fbc"></i><i style="--shade:#9fbbdd"></i><i style="--shade:#b2c9e4"></i><i style="--shade:#c5d6eb"></i><i style="--shade:#d9e4f1"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #001d35; color: #ffffff;">
+        <span>on-secondary-fixed</span>
+        <span>#001D35</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#00070d"></i><i style="--shade:#000d18"></i><i style="--shade:#001322"></i><i style="--shade:#00192d"></i><i style="--shade:#001d35"></i><i style="--shade:#334a5d"></i><i style="--shade:#667786"></i><i style="--shade:#99a5ae"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #2d4965; color: #ffffff;">
+        <span>on-secondary-fixed-variant</span>
+        <span>#2D4965</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0b1219"></i><i style="--shade:#14212d"></i><i style="--shade:#1d2f42"></i><i style="--shade:#263e56"></i><i style="--shade:#2d4965"></i><i style="--shade:#576d84"></i><i style="--shade:#8192a3"></i><i style="--shade:#abb6c1"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #dae2fd; color: #000000;">
+        <span>on-surface</span>
+        <span>#DAE2FD</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#37393f"></i><i style="--shade:#626672"></i><i style="--shade:#8e93a4"></i><i style="--shade:#b9c0d7"></i><i style="--shade:#dae2fd"></i><i style="--shade:#e1e8fd"></i><i style="--shade:#e9eefe"></i><i style="--shade:#f0f3fe"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #c4c7c8; color: #000000;">
+        <span>on-surface-variant</span>
+        <span>#C4C7C8</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#313232"></i><i style="--shade:#585a5a"></i><i style="--shade:#7f8182"></i><i style="--shade:#a7a9aa"></i><i style="--shade:#c4c7c8"></i><i style="--shade:#d0d2d3"></i><i style="--shade:#dcddde"></i><i style="--shade:#e7e9e9"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #620040; color: #ffffff;">
+        <span>on-tertiary</span>
+        <span>#620040</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#190010"></i><i style="--shade:#2c001d"></i><i style="--shade:#40002a"></i><i style="--shade:#530036"></i><i style="--shade:#620040"></i><i style="--shade:#813366"></i><i style="--shade:#a1668c"></i><i style="--shade:#c099b3"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ab3779; color: #ffffff;">
+        <span>on-tertiary-container</span>
+        <span>#AB3779</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#2b0e1e"></i><i style="--shade:#4d1936"></i><i style="--shade:#6f244f"></i><i style="--shade:#912f67"></i><i style="--shade:#ab3779"></i><i style="--shade:#bc5f94"></i><i style="--shade:#cd87af"></i><i style="--shade:#ddafc9"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #3d0026; color: #ffffff;">
+        <span>on-tertiary-fixed</span>
+        <span>#3D0026</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0f000a"></i><i style="--shade:#1b0011"></i><i style="--shade:#280019"></i><i style="--shade:#340020"></i><i style="--shade:#3d0026"></i><i style="--shade:#643351"></i><i style="--shade:#8b667d"></i><i style="--shade:#b199a8"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #85145a; color: #ffffff;">
+        <span>on-tertiary-fixed-variant</span>
+        <span>#85145A</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#210517"></i><i style="--shade:#3c0928"></i><i style="--shade:#560d3b"></i><i style="--shade:#71114d"></i><i style="--shade:#85145a"></i><i style="--shade:#9d437b"></i><i style="--shade:#b6729c"></i><i style="--shade:#cea1bd"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #8e9192; color: #ffffff;">
+        <span>outline</span>
+        <span>#8E9192</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#242425"></i><i style="--shade:#404142"></i><i style="--shade:#5c5e5f"></i><i style="--shade:#797b7c"></i><i style="--shade:#8e9192"></i><i style="--shade:#a5a7a8"></i><i style="--shade:#bbbdbe"></i><i style="--shade:#d2d3d3"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #444748; color: #ffffff;">
+        <span>outline-variant</span>
+        <span>#444748</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#111212"></i><i style="--shade:#1f2020"></i><i style="--shade:#2c2e2f"></i><i style="--shade:#3a3c3d"></i><i style="--shade:#444748"></i><i style="--shade:#696c6d"></i><i style="--shade:#8f9191"></i><i style="--shade:#b4b5b6"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffffff; color: #000000;">
+        <span>primary</span>
+        <span>#FFFFFF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#404040"></i><i style="--shade:#737373"></i><i style="--shade:#a6a6a6"></i><i style="--shade:#d9d9d9"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #e2e2e2; color: #000000;">
+        <span>primary-container</span>
+        <span>#E2E2E2</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#393939"></i><i style="--shade:#666666"></i><i style="--shade:#939393"></i><i style="--shade:#c0c0c0"></i><i style="--shade:#e2e2e2"></i><i style="--shade:#e8e8e8"></i><i style="--shade:#eeeeee"></i><i style="--shade:#f3f3f3"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #e2e2e2; color: #000000;">
+        <span>primary-fixed</span>
+        <span>#E2E2E2</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#393939"></i><i style="--shade:#666666"></i><i style="--shade:#939393"></i><i style="--shade:#c0c0c0"></i><i style="--shade:#e2e2e2"></i><i style="--shade:#e8e8e8"></i><i style="--shade:#eeeeee"></i><i style="--shade:#f3f3f3"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #c6c6c7; color: #000000;">
+        <span>primary-fixed-dim</span>
+        <span>#C6C6C7</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#323232"></i><i style="--shade:#59595a"></i><i style="--shade:#818181"></i><i style="--shade:#a8a8a9"></i><i style="--shade:#c6c6c7"></i><i style="--shade:#d1d1d2"></i><i style="--shade:#dddddd"></i><i style="--shade:#e8e8e9"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #adc9eb; color: #000000;">
+        <span>secondary</span>
+        <span>#ADC9EB</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#2b323b"></i><i style="--shade:#4e5a6a"></i><i style="--shade:#708399"></i><i style="--shade:#93abc8"></i><i style="--shade:#adc9eb"></i><i style="--shade:#bdd4ef"></i><i style="--shade:#cedff3"></i><i style="--shade:#dee9f7"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #304b68; color: #ffffff;">
+        <span>secondary-container</span>
+        <span>#304B68</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0c131a"></i><i style="--shade:#16222f"></i><i style="--shade:#1f3144"></i><i style="--shade:#294058"></i><i style="--shade:#304b68"></i><i style="--shade:#596f86"></i><i style="--shade:#8393a4"></i><i style="--shade:#acb7c3"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #d0e4ff; color: #000000;">
+        <span>secondary-fixed</span>
+        <span>#D0E4FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#343940"></i><i style="--shade:#5e6773"></i><i style="--shade:#8794a6"></i><i style="--shade:#b1c2d9"></i><i style="--shade:#d0e4ff"></i><i style="--shade:#d9e9ff"></i><i style="--shade:#e3efff"></i><i style="--shade:#ecf4ff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #adc9eb; color: #000000;">
+        <span>secondary-fixed-dim</span>
+        <span>#ADC9EB</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#2b323b"></i><i style="--shade:#4e5a6a"></i><i style="--shade:#708399"></i><i style="--shade:#93abc8"></i><i style="--shade:#adc9eb"></i><i style="--shade:#bdd4ef"></i><i style="--shade:#cedff3"></i><i style="--shade:#dee9f7"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #0b1326; color: #ffffff;">
+        <span>surface</span>
+        <span>#0B1326</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#03050a"></i><i style="--shade:#050911"></i><i style="--shade:#070c19"></i><i style="--shade:#091020"></i><i style="--shade:#0b1326"></i><i style="--shade:#3c4251"></i><i style="--shade:#6d717d"></i><i style="--shade:#9da1a8"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #31394d; color: #ffffff;">
+        <span>surface-bright</span>
+        <span>#31394D</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0c0e13"></i><i style="--shade:#161a23"></i><i style="--shade:#202532"></i><i style="--shade:#2a3041"></i><i style="--shade:#31394d"></i><i style="--shade:#5a6171"></i><i style="--shade:#838894"></i><i style="--shade:#adb0b8"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #171f33; color: #ffffff;">
+        <span>surface-container</span>
+        <span>#171F33</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#06080d"></i><i style="--shade:#0a0e17"></i><i style="--shade:#0f1421"></i><i style="--shade:#141a2b"></i><i style="--shade:#171f33"></i><i style="--shade:#454c5c"></i><i style="--shade:#747985"></i><i style="--shade:#a2a5ad"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #222a3d; color: #ffffff;">
+        <span>surface-container-high</span>
+        <span>#222A3D</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#090b0f"></i><i style="--shade:#0f131b"></i><i style="--shade:#161b28"></i><i style="--shade:#1d2434"></i><i style="--shade:#222a3d"></i><i style="--shade:#4e5564"></i><i style="--shade:#7a7f8b"></i><i style="--shade:#a7aab1"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #2d3449; color: #ffffff;">
+        <span>surface-container-highest</span>
+        <span>#2D3449</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0b0d12"></i><i style="--shade:#141721"></i><i style="--shade:#1d222f"></i><i style="--shade:#262c3e"></i><i style="--shade:#2d3449"></i><i style="--shade:#575d6d"></i><i style="--shade:#818592"></i><i style="--shade:#abaeb6"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #131b2e; color: #ffffff;">
+        <span>surface-container-low</span>
+        <span>#131B2E</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#05070c"></i><i style="--shade:#090c15"></i><i style="--shade:#0c121e"></i><i style="--shade:#101727"></i><i style="--shade:#131b2e"></i><i style="--shade:#424958"></i><i style="--shade:#717682"></i><i style="--shade:#a1a4ab"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #060e20; color: #ffffff;">
+        <span>surface-container-lowest</span>
+        <span>#060E20</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#020408"></i><i style="--shade:#03060e"></i><i style="--shade:#040915"></i><i style="--shade:#050c1b"></i><i style="--shade:#060e20"></i><i style="--shade:#383e4d"></i><i style="--shade:#6a6e79"></i><i style="--shade:#9b9fa6"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #0b1326; color: #ffffff;">
+        <span>surface-dim</span>
+        <span>#0B1326</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#03050a"></i><i style="--shade:#050911"></i><i style="--shade:#070c19"></i><i style="--shade:#091020"></i><i style="--shade:#0b1326"></i><i style="--shade:#3c4251"></i><i style="--shade:#6d717d"></i><i style="--shade:#9da1a8"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #c6c6c7; color: #000000;">
+        <span>surface-tint</span>
+        <span>#C6C6C7</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#323232"></i><i style="--shade:#59595a"></i><i style="--shade:#818181"></i><i style="--shade:#a8a8a9"></i><i style="--shade:#c6c6c7"></i><i style="--shade:#d1d1d2"></i><i style="--shade:#dddddd"></i><i style="--shade:#e8e8e9"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #2d3449; color: #ffffff;">
+        <span>surface-variant</span>
+        <span>#2D3449</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0b0d12"></i><i style="--shade:#141721"></i><i style="--shade:#1d222f"></i><i style="--shade:#262c3e"></i><i style="--shade:#2d3449"></i><i style="--shade:#575d6d"></i><i style="--shade:#818592"></i><i style="--shade:#abaeb6"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffffff; color: #000000;">
+        <span>tertiary</span>
+        <span>#FFFFFF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#404040"></i><i style="--shade:#737373"></i><i style="--shade:#a6a6a6"></i><i style="--shade:#d9d9d9"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffd8e7; color: #000000;">
+        <span>tertiary-container</span>
+        <span>#FFD8E7</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#40363a"></i><i style="--shade:#736168"></i><i style="--shade:#a68c96"></i><i style="--shade:#d9b8c4"></i><i style="--shade:#ffd8e7"></i><i style="--shade:#ffe0ec"></i><i style="--shade:#ffe8f1"></i><i style="--shade:#ffeff5"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffd8e7; color: #000000;">
+        <span>tertiary-fixed</span>
+        <span>#FFD8E7</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#40363a"></i><i style="--shade:#736168"></i><i style="--shade:#a68c96"></i><i style="--shade:#d9b8c4"></i><i style="--shade:#ffd8e7"></i><i style="--shade:#ffe0ec"></i><i style="--shade:#ffe8f1"></i><i style="--shade:#ffeff5"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffafd3; color: #000000;">
+        <span>tertiary-fixed-dim</span>
+        <span>#FFAFD3</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#402c35"></i><i style="--shade:#734f5f"></i><i style="--shade:#a67289"></i><i style="--shade:#d995b3"></i><i style="--shade:#ffafd3"></i><i style="--shade:#ffbfdc"></i><i style="--shade:#ffcfe5"></i><i style="--shade:#ffdfed"></i>
+      </div>
+    </article>
+        </div>
+      </div>
+
+      <!-- TYPOGRAPHY TAB -->
+      <div id="tab-typography" class="tab-content">
+        <div class="grid-auto">
+          <article class="card">
+        <div class="type-header">
+          <span>body-lg</span>
+          <span>Inter</span>
+        </div>
+        <p class="type-sample" style="font-family:Inter;font-size: 6.5rem;font-weight:400">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>body-md</span>
+          <span>Inter</span>
+        </div>
+        <p class="type-sample" style="font-family:Inter;font-size: 6.5rem;font-weight:400">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>display-lg</span>
+          <span>Inter</span>
+        </div>
+        <p class="type-sample" style="font-family:Inter;font-size: 6.5rem;font-weight:700;letter-spacing:-0.04em">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>headline-lg</span>
+          <span>Inter</span>
+        </div>
+        <p class="type-sample" style="font-family:Inter;font-size: 6.5rem;font-weight:600;letter-spacing:-0.02em">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>headline-md</span>
+          <span>Inter</span>
+        </div>
+        <p class="type-sample" style="font-family:Inter;font-size: 6.5rem;font-weight:500">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>label-sm</span>
+          <span>Inter</span>
+        </div>
+        <p class="type-sample" style="font-family:Inter;font-size: 6.5rem;font-weight:600;letter-spacing:0.05em">Aa</p>
+      </article>
+        </div>
+      </div>
+
+      <!-- LAYOUT (SPACING) TAB -->
+      <div id="tab-layout" class="tab-content">
+        <div class="masonry">
+          <div class="card">
+            <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">All Spacing Tokens</h3>
+            <div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">card-gap</strong>
+          <span style="color:var(--text-muted);">16px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:35.2px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">container-padding</strong>
+          <span style="color:var(--text-muted);">24px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:52.800000000000004px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">glass-padding</strong>
+          <span style="color:var(--text-muted);">20px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:44px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">section-margin</strong>
+          <span style="color:var(--text-muted);">40px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:88px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">unit</strong>
+          <span style="color:var(--text-muted);">8px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:17.6px"></i></div>
+      </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- SHAPES (ROUNDED) TAB -->
+      <div id="tab-shapes" class="tab-content">
+        <div class="masonry">
+          <div class="card">
+            <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">All Rounded Tokens</h3>
+            <div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">DEFAULT</strong>
+          <span style="color:var(--text-muted);">0.5rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.5rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">full</strong>
+          <span style="color:var(--text-muted);">9999px</span>
+        </div>
+        <div class="rounded-chip" style="--radius:9999px"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">lg</strong>
+          <span style="color:var(--text-muted);">1rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:1rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">md</strong>
+          <span style="color:var(--text-muted);">0.75rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.75rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">sm</strong>
+          <span style="color:var(--text-muted);">0.25rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.25rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">xl</strong>
+          <span style="color:var(--text-muted);">1.5rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:1.5rem"></div>
+      </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- COMPONENTS TAB -->
+      <div id="tab-components" class="tab-content">
+        <div class="masonry">
+          <article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-ghost</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>rgba(255, 255, 255, 0.05)</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>1.5rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#ffffff</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Inter 12px/16px (600)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-primary</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#ffffff</span>
+      </div><div class="component-prop">
+        <strong>height</strong>
+        <span>48px</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>0 24px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>1.5rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#2f3131</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Inter 12px/16px (600)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-primary-hover</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#c6c6c7</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">glass-card-elevated</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>rgba(255, 255, 255, 0.2)</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>20px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>1.5rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#ffffff</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">glass-card-standard</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>rgba(255, 255, 255, 0.1)</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>20px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>1rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#ffffff</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">input-field</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>rgba(255, 255, 255, 0.1)</span>
+      </div><div class="component-prop">
+        <strong>height</strong>
+        <span>48px</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>20px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>1.5rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#ffffff</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Inter 16px/24px (400)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">list-item-interactive</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>transparent</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>12px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>0.75rem</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">list-item-interactive-hover</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>rgba(255, 255, 255, 0.1)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">metric-label</h3>
+      <div>
+      <div class="component-prop">
+        <strong>textColor</strong>
+        <span>#c4c7c8</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Inter 12px/16px (600)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">weather-display-large</h3>
+      <div>
+      <div class="component-prop">
+        <strong>textColor</strong>
+        <span>#ffffff</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Inter 84px/90px (700)</span>
+      </div>
+      </div>
+    </article>
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+  <script>
+    function showTab(event, tabId) {
+      document.querySelectorAll('.tab-content').forEach(el => el.classList.remove('active'));
+      document.querySelectorAll('.tab-btn').forEach(el => el.classList.remove('active'));
+      
+      document.getElementById(tabId).classList.add('active');
+      event.currentTarget.classList.add('active');
+    }
+  </script>
+</body>
+</html>

--- a/examples/paws-and-paths/preview.html
+++ b/examples/paws-and-paths/preview.html
@@ -1,0 +1,1237 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Paws &amp; Paths - DESIGN.md Show</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&family=Noto+Serif:wght@400;700&display=swap');
+
+    :root {
+      --bg-dark: #242424;
+      --board-bg: #e2e2db;
+      --board-border: #7951ff;
+      --card-bg: #f5f5f0;
+      --text-main: #333333;
+      --text-muted: #888888;
+      --radius-xl: 1.5rem;
+      --radius-lg: 1rem;
+      --radius-md: 0.75rem;
+      --radius-sm: 0.5rem;
+      --radius-pill: 9999px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "Manrope", sans-serif;
+      color: var(--text-main);
+      background-color: var(--bg-dark);
+      background-image: radial-gradient(#3a3a3a 1px, transparent 0);
+      background-size: 20px 20px;
+      padding: 2rem 4rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .page-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      color: white;
+      padding: 0 1rem;
+    }
+
+    .page-title {
+      font-weight: 700;
+      font-size: 1.25rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    
+    .page-title svg {
+      width: 24px;
+      height: 24px;
+      fill: currentColor;
+    }
+
+    .page-actions {
+      display: flex;
+      gap: 0.5rem;
+      color: #999;
+    }
+
+    .page-actions svg {
+      width: 24px;
+      height: 24px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 2;
+    }
+
+    .board-container {
+      border: 4px solid var(--board-border);
+      border-radius: var(--radius-xl);
+      background: var(--board-bg);
+      padding: 1.5rem;
+      box-shadow: 0 24px 48px rgba(0,0,0,0.2);
+    }
+
+    .tabs {
+      display: flex;
+      gap: 1.5rem;
+      margin-bottom: 1.5rem;
+      border-bottom: 2px solid rgba(0,0,0,0.05);
+      padding-bottom: 0.5rem;
+    }
+
+    .tab-btn {
+      background: none;
+      border: none;
+      color: var(--text-muted);
+      font-family: "Manrope", sans-serif;
+      font-weight: 700;
+      font-size: 1rem;
+      cursor: pointer;
+      padding: 0.5rem 0.25rem;
+      border-bottom: 3px solid transparent;
+      margin-bottom: -0.5rem;
+      transition: color 0.2s, border-color 0.2s;
+    }
+
+    .tab-btn:hover {
+      color: var(--text-main);
+    }
+
+    .tab-btn.active {
+      color: var(--text-main);
+      border-bottom-color: var(--board-border);
+    }
+
+    .tab-content {
+      display: none;
+      animation: fadeIn 0.3s ease;
+    }
+
+    .tab-content.active {
+      display: block;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(5px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    /* Column layouts for Overview */
+    .grid-4 {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 1.5rem;
+      align-items: start;
+    }
+
+    .column {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    /* Masonry layout for inner tabs */
+    .masonry {
+      column-count: 4;
+      column-gap: 1.5rem;
+    }
+    .masonry > * {
+      break-inside: avoid;
+      margin-bottom: 1.5rem;
+    }
+    
+    .grid-auto {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 1.5rem;
+      align-items: start;
+    }
+
+    /* Cards */
+    .card {
+      background: var(--card-bg);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+      padding: 1.25rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    /* Color Card */
+    .color-card {
+      padding: 0;
+      gap: 0;
+    }
+    .color-main {
+      padding: 1.25rem;
+      display: flex;
+      justify-content: space-between;
+      font-weight: 700;
+      font-size: 0.9rem;
+      min-height: 120px;
+    }
+    .color-shades {
+      display: flex;
+      height: 36px;
+    }
+    .color-shades i {
+      flex: 1;
+      background: var(--shade);
+    }
+
+    /* Typography Card */
+    .type-header {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin-bottom: 2.5rem;
+    }
+    .type-sample {
+      margin: 0;
+      text-align: center;
+      font-size: 6.5rem;
+      line-height: 1;
+      color: #333;
+      padding-bottom: 1.5rem;
+    }
+
+    /* Dimension Rows */
+    .dim-row {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 0.5rem;
+      font-size: 0.85rem;
+      margin-bottom: 0.5rem;
+      align-items: center;
+    }
+    .dim-bar {
+      grid-column: 1 / -1;
+      height: 6px;
+      border-radius: var(--radius-pill);
+      background: rgba(0,0,0,0.05);
+      margin-bottom: 1rem;
+    }
+    .dim-bar i {
+      display: block;
+      height: 100%;
+      border-radius: var(--radius-pill);
+      background: #5d665b;
+      width: var(--width);
+    }
+    .rounded-chip {
+      height: 32px;
+      background: rgba(0,0,0,0.1);
+      border-radius: var(--radius);
+      margin-top: 0.25rem;
+    }
+
+    /* Components */
+    .component-prop {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.85rem;
+      padding: 0.35rem 0;
+      border-bottom: 1px solid rgba(0,0,0,0.05);
+    }
+    .component-prop:last-child {
+      border-bottom: none;
+    }
+    .component-prop strong {
+      color: var(--text-muted);
+      font-weight: 400;
+    }
+
+    .diagnostics {
+      margin-bottom: 1rem;
+      border-radius: var(--radius-md);
+      padding: 1rem;
+      background: #ffebee;
+      color: #c62828;
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 1200px) {
+      .grid { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (max-width: 768px) {
+      .grid { grid-template-columns: 1fr; }
+      body { padding: 1rem; }
+    }
+  </style>
+</head>
+<body>
+  <header class="page-header">
+    <div class="page-title">
+      <svg viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/></svg>
+      Paws &amp; Paths
+    </div>
+    <div class="page-actions">
+      <svg viewBox="0 0 24 24"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon></svg>
+      <svg viewBox="0 0 24 24"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"></path></svg>
+      <svg viewBox="0 0 24 24"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h3a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2h-3"></path></svg>
+    </div>
+  </header>
+
+  <div class="board-container">
+    <div class="diagnostics">
+    <p style="margin:0 0 0.5rem;font-weight:bold;">Diagnostics: 0 errors, 33 warnings</p>
+    <ul style="margin:0;padding-left:1.5rem;"><li>[colors.surface] &#39;surface&#39; is defined but never referenced by any component.</li><li>[colors.surface-dim] &#39;surface-dim&#39; is defined but never referenced by any component.</li><li>[colors.surface-bright] &#39;surface-bright&#39; is defined but never referenced by any component.</li><li>[colors.surface-container] &#39;surface-container&#39; is defined but never referenced by any component.</li><li>[colors.surface-container-highest] &#39;surface-container-highest&#39; is defined but never referenced by any component.</li><li>[colors.on-surface-variant] &#39;on-surface-variant&#39; is defined but never referenced by any component.</li></ul>
+  </div>
+    
+    <nav class="tabs">
+      <button class="tab-btn active" onclick="showTab(event, 'tab-overview')">Overview</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-colors')">Colors (47)</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-typography')">Typography (8)</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-layout')">Layout (8)</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-shapes')">Shapes (6)</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-components')">Components (10)</button>
+    </nav>
+
+    <main class="board">
+      
+      <!-- OVERVIEW TAB -->
+      <div id="tab-overview" class="tab-content active">
+        <div class="grid-4">
+          <div class="column">
+            <article class="card color-card">
+      <div class="color-main" style="background-color: #f9f9ff; color: #000000;">
+        <span>background</span>
+        <span>#F9F9FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#3e3e40"></i><i style="--shade:#707073"></i><i style="--shade:#a2a2a6"></i><i style="--shade:#d4d4d9"></i><i style="--shade:#f9f9ff"></i><i style="--shade:#fafaff"></i><i style="--shade:#fbfbff"></i><i style="--shade:#fdfdff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ba1a1a; color: #ffffff;">
+        <span>error</span>
+        <span>#BA1A1A</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#2f0707"></i><i style="--shade:#540c0c"></i><i style="--shade:#791111"></i><i style="--shade:#9e1616"></i><i style="--shade:#ba1a1a"></i><i style="--shade:#c84848"></i><i style="--shade:#d67676"></i><i style="--shade:#e3a3a3"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffdad6; color: #000000;">
+        <span>error-container</span>
+        <span>#FFDAD6</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#403736"></i><i style="--shade:#736260"></i><i style="--shade:#a68e8b"></i><i style="--shade:#d9b9b6"></i><i style="--shade:#ffdad6"></i><i style="--shade:#ffe1de"></i><i style="--shade:#ffe9e6"></i><i style="--shade:#fff0ef"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ebf1ff; color: #000000;">
+        <span>inverse-on-surface</span>
+        <span>#EBF1FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#3b3c40"></i><i style="--shade:#6a6c73"></i><i style="--shade:#999da6"></i><i style="--shade:#c8cdd9"></i><i style="--shade:#ebf1ff"></i><i style="--shade:#eff4ff"></i><i style="--shade:#f3f7ff"></i><i style="--shade:#f7f9ff"></i>
+      </div>
+    </article>
+          </div>
+          <div class="column">
+            <article class="card">
+        <div class="type-header">
+          <span>body-lg</span>
+          <span>Plus Jakarta Sans</span>
+        </div>
+        <p class="type-sample" style="font-family:Plus Jakarta Sans;font-size: 6.5rem;font-weight:400">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>body-md</span>
+          <span>Plus Jakarta Sans</span>
+        </div>
+        <p class="type-sample" style="font-family:Plus Jakarta Sans;font-size: 6.5rem;font-weight:400">Aa</p>
+      </article>
+          </div>
+          <div class="column">
+            <div class="card">
+              <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">Spacing</h3>
+              <div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">base</strong>
+          <span style="color:var(--text-muted);">8px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:17.6px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">gutter</strong>
+          <span style="color:var(--text-muted);">16px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:35.2px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">lg</strong>
+          <span style="color:var(--text-muted);">40px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:88px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">margin</strong>
+          <span style="color:var(--text-muted);">24px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:52.800000000000004px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">md</strong>
+          <span style="color:var(--text-muted);">24px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:52.800000000000004px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">sm</strong>
+          <span style="color:var(--text-muted);">12px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:26.400000000000002px"></i></div>
+      </div>
+            </div>
+            <article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">badge-status</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#1abdff</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>4px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>9999px</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#004966</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Plus Jakarta Sans 12px/16px (500)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-primary</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#855300</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>24px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>1rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#ffffff</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Plus Jakarta Sans 14px/20px (600)</span>
+      </div>
+      </div>
+    </article>
+          </div>
+          <div class="column">
+            <div class="card">
+              <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">Rounded</h3>
+              <div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">DEFAULT</strong>
+          <span style="color:var(--text-muted);">0.5rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.5rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">full</strong>
+          <span style="color:var(--text-muted);">9999px</span>
+        </div>
+        <div class="rounded-chip" style="--radius:9999px"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">lg</strong>
+          <span style="color:var(--text-muted);">1rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:1rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">md</strong>
+          <span style="color:var(--text-muted);">0.75rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.75rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">sm</strong>
+          <span style="color:var(--text-muted);">0.25rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.25rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">xl</strong>
+          <span style="color:var(--text-muted);">1.5rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:1.5rem"></div>
+      </div>
+            </div>
+            <article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-primary-hover</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#f59e0b</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#613b00</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-secondary</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#0058be</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>24px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>1rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#ffffff</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Plus Jakarta Sans 14px/20px (600)</span>
+      </div>
+      </div>
+    </article>
+          </div>
+        </div>
+      </div>
+
+      <!-- COLORS TAB -->
+      <div id="tab-colors" class="tab-content">
+        <div class="grid-auto">
+          <article class="card color-card">
+      <div class="color-main" style="background-color: #f9f9ff; color: #000000;">
+        <span>background</span>
+        <span>#F9F9FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#3e3e40"></i><i style="--shade:#707073"></i><i style="--shade:#a2a2a6"></i><i style="--shade:#d4d4d9"></i><i style="--shade:#f9f9ff"></i><i style="--shade:#fafaff"></i><i style="--shade:#fbfbff"></i><i style="--shade:#fdfdff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ba1a1a; color: #ffffff;">
+        <span>error</span>
+        <span>#BA1A1A</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#2f0707"></i><i style="--shade:#540c0c"></i><i style="--shade:#791111"></i><i style="--shade:#9e1616"></i><i style="--shade:#ba1a1a"></i><i style="--shade:#c84848"></i><i style="--shade:#d67676"></i><i style="--shade:#e3a3a3"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffdad6; color: #000000;">
+        <span>error-container</span>
+        <span>#FFDAD6</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#403736"></i><i style="--shade:#736260"></i><i style="--shade:#a68e8b"></i><i style="--shade:#d9b9b6"></i><i style="--shade:#ffdad6"></i><i style="--shade:#ffe1de"></i><i style="--shade:#ffe9e6"></i><i style="--shade:#fff0ef"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ebf1ff; color: #000000;">
+        <span>inverse-on-surface</span>
+        <span>#EBF1FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#3b3c40"></i><i style="--shade:#6a6c73"></i><i style="--shade:#999da6"></i><i style="--shade:#c8cdd9"></i><i style="--shade:#ebf1ff"></i><i style="--shade:#eff4ff"></i><i style="--shade:#f3f7ff"></i><i style="--shade:#f7f9ff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffb95f; color: #000000;">
+        <span>inverse-primary</span>
+        <span>#FFB95F</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#402e18"></i><i style="--shade:#73532b"></i><i style="--shade:#a6783e"></i><i style="--shade:#d99d51"></i><i style="--shade:#ffb95f"></i><i style="--shade:#ffc77f"></i><i style="--shade:#ffd59f"></i><i style="--shade:#ffe3bf"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #2a313d; color: #ffffff;">
+        <span>inverse-surface</span>
+        <span>#2A313D</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0b0c0f"></i><i style="--shade:#13161b"></i><i style="--shade:#1b2028"></i><i style="--shade:#242a34"></i><i style="--shade:#2a313d"></i><i style="--shade:#555a64"></i><i style="--shade:#7f838b"></i><i style="--shade:#aaadb1"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #151c27; color: #ffffff;">
+        <span>on-background</span>
+        <span>#151C27</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#05070a"></i><i style="--shade:#090d12"></i><i style="--shade:#0e1219"></i><i style="--shade:#121821"></i><i style="--shade:#151c27"></i><i style="--shade:#444952"></i><i style="--shade:#73777d"></i><i style="--shade:#a1a4a9"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffffff; color: #000000;">
+        <span>on-error</span>
+        <span>#FFFFFF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#404040"></i><i style="--shade:#737373"></i><i style="--shade:#a6a6a6"></i><i style="--shade:#d9d9d9"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #93000a; color: #ffffff;">
+        <span>on-error-container</span>
+        <span>#93000A</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#250003"></i><i style="--shade:#420005"></i><i style="--shade:#600007"></i><i style="--shade:#7d0009"></i><i style="--shade:#93000a"></i><i style="--shade:#a9333b"></i><i style="--shade:#be666c"></i><i style="--shade:#d4999d"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffffff; color: #000000;">
+        <span>on-primary</span>
+        <span>#FFFFFF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#404040"></i><i style="--shade:#737373"></i><i style="--shade:#a6a6a6"></i><i style="--shade:#d9d9d9"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #613b00; color: #ffffff;">
+        <span>on-primary-container</span>
+        <span>#613B00</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#180f00"></i><i style="--shade:#2c1b00"></i><i style="--shade:#3f2600"></i><i style="--shade:#523200"></i><i style="--shade:#613b00"></i><i style="--shade:#816233"></i><i style="--shade:#a08966"></i><i style="--shade:#c0b199"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #2a1700; color: #ffffff;">
+        <span>on-primary-fixed</span>
+        <span>#2A1700</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0b0600"></i><i style="--shade:#130a00"></i><i style="--shade:#1b0f00"></i><i style="--shade:#241400"></i><i style="--shade:#2a1700"></i><i style="--shade:#554533"></i><i style="--shade:#7f7466"></i><i style="--shade:#aaa299"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #653e00; color: #ffffff;">
+        <span>on-primary-fixed-variant</span>
+        <span>#653E00</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#191000"></i><i style="--shade:#2d1c00"></i><i style="--shade:#422800"></i><i style="--shade:#563500"></i><i style="--shade:#653e00"></i><i style="--shade:#846533"></i><i style="--shade:#a38b66"></i><i style="--shade:#c1b299"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffffff; color: #000000;">
+        <span>on-secondary</span>
+        <span>#FFFFFF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#404040"></i><i style="--shade:#737373"></i><i style="--shade:#a6a6a6"></i><i style="--shade:#d9d9d9"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #fefcff; color: #000000;">
+        <span>on-secondary-container</span>
+        <span>#FEFCFF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#403f40"></i><i style="--shade:#727173"></i><i style="--shade:#a5a4a6"></i><i style="--shade:#d8d6d9"></i><i style="--shade:#fefcff"></i><i style="--shade:#fefdff"></i><i style="--shade:#fefdff"></i><i style="--shade:#fffeff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #001a42; color: #ffffff;">
+        <span>on-secondary-fixed</span>
+        <span>#001A42</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#000711"></i><i style="--shade:#000c1e"></i><i style="--shade:#00112b"></i><i style="--shade:#001638"></i><i style="--shade:#001a42"></i><i style="--shade:#334868"></i><i style="--shade:#66768e"></i><i style="--shade:#99a3b3"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #004395; color: #ffffff;">
+        <span>on-secondary-fixed-variant</span>
+        <span>#004395</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#001125"></i><i style="--shade:#001e43"></i><i style="--shade:#002c61"></i><i style="--shade:#00397f"></i><i style="--shade:#004395"></i><i style="--shade:#3369aa"></i><i style="--shade:#668ebf"></i><i style="--shade:#99b4d5"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #151c27; color: #ffffff;">
+        <span>on-surface</span>
+        <span>#151C27</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#05070a"></i><i style="--shade:#090d12"></i><i style="--shade:#0e1219"></i><i style="--shade:#121821"></i><i style="--shade:#151c27"></i><i style="--shade:#444952"></i><i style="--shade:#73777d"></i><i style="--shade:#a1a4a9"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #534434; color: #ffffff;">
+        <span>on-surface-variant</span>
+        <span>#534434</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#15110d"></i><i style="--shade:#251f17"></i><i style="--shade:#362c22"></i><i style="--shade:#473a2c"></i><i style="--shade:#534434"></i><i style="--shade:#75695d"></i><i style="--shade:#988f85"></i><i style="--shade:#bab4ae"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffffff; color: #000000;">
+        <span>on-tertiary</span>
+        <span>#FFFFFF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#404040"></i><i style="--shade:#737373"></i><i style="--shade:#a6a6a6"></i><i style="--shade:#d9d9d9"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #004966; color: #ffffff;">
+        <span>on-tertiary-container</span>
+        <span>#004966</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#00121a"></i><i style="--shade:#00212e"></i><i style="--shade:#002f42"></i><i style="--shade:#003e57"></i><i style="--shade:#004966"></i><i style="--shade:#336d85"></i><i style="--shade:#6692a3"></i><i style="--shade:#99b6c2"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #001e2d; color: #ffffff;">
+        <span>on-tertiary-fixed</span>
+        <span>#001E2D</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#00080b"></i><i style="--shade:#000d14"></i><i style="--shade:#00141d"></i><i style="--shade:#001a26"></i><i style="--shade:#001e2d"></i><i style="--shade:#334b57"></i><i style="--shade:#667881"></i><i style="--shade:#99a5ab"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #004c6a; color: #ffffff;">
+        <span>on-tertiary-fixed-variant</span>
+        <span>#004C6A</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#00131b"></i><i style="--shade:#002230"></i><i style="--shade:#003145"></i><i style="--shade:#00415a"></i><i style="--shade:#004c6a"></i><i style="--shade:#337088"></i><i style="--shade:#6694a6"></i><i style="--shade:#99b7c3"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #867461; color: #ffffff;">
+        <span>outline</span>
+        <span>#867461</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#221d18"></i><i style="--shade:#3c342c"></i><i style="--shade:#574b3f"></i><i style="--shade:#726352"></i><i style="--shade:#867461"></i><i style="--shade:#9e9081"></i><i style="--shade:#b6aca0"></i><i style="--shade:#cfc7c0"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #d8c3ad; color: #000000;">
+        <span>outline-variant</span>
+        <span>#D8C3AD</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#36312b"></i><i style="--shade:#61584e"></i><i style="--shade:#8c7f70"></i><i style="--shade:#b8a693"></i><i style="--shade:#d8c3ad"></i><i style="--shade:#e0cfbd"></i><i style="--shade:#e8dbce"></i><i style="--shade:#efe7de"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #855300; color: #ffffff;">
+        <span>primary</span>
+        <span>#855300</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#211500"></i><i style="--shade:#3c2500"></i><i style="--shade:#563600"></i><i style="--shade:#714700"></i><i style="--shade:#855300"></i><i style="--shade:#9d7533"></i><i style="--shade:#b69866"></i><i style="--shade:#ceba99"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #f59e0b; color: #000000;">
+        <span>primary-container</span>
+        <span>#F59E0B</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#3d2803"></i><i style="--shade:#6e4705"></i><i style="--shade:#9f6707"></i><i style="--shade:#d08609"></i><i style="--shade:#f59e0b"></i><i style="--shade:#f7b13c"></i><i style="--shade:#f9c56d"></i><i style="--shade:#fbd89d"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffddb8; color: #000000;">
+        <span>primary-fixed</span>
+        <span>#FFDDB8</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#40372e"></i><i style="--shade:#736353"></i><i style="--shade:#a69078"></i><i style="--shade:#d9bc9c"></i><i style="--shade:#ffddb8"></i><i style="--shade:#ffe4c6"></i><i style="--shade:#ffebd4"></i><i style="--shade:#fff1e3"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffb95f; color: #000000;">
+        <span>primary-fixed-dim</span>
+        <span>#FFB95F</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#402e18"></i><i style="--shade:#73532b"></i><i style="--shade:#a6783e"></i><i style="--shade:#d99d51"></i><i style="--shade:#ffb95f"></i><i style="--shade:#ffc77f"></i><i style="--shade:#ffd59f"></i><i style="--shade:#ffe3bf"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #0058be; color: #ffffff;">
+        <span>secondary</span>
+        <span>#0058BE</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#001630"></i><i style="--shade:#002855"></i><i style="--shade:#00397c"></i><i style="--shade:#004ba2"></i><i style="--shade:#0058be"></i><i style="--shade:#3379cb"></i><i style="--shade:#669bd8"></i><i style="--shade:#99bce5"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #2170e4; color: #ffffff;">
+        <span>secondary-container</span>
+        <span>#2170E4</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#081c39"></i><i style="--shade:#0f3267"></i><i style="--shade:#154994"></i><i style="--shade:#1c5fc2"></i><i style="--shade:#2170e4"></i><i style="--shade:#4d8de9"></i><i style="--shade:#7aa9ef"></i><i style="--shade:#a6c6f4"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #d8e2ff; color: #000000;">
+        <span>secondary-fixed</span>
+        <span>#D8E2FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#363940"></i><i style="--shade:#616673"></i><i style="--shade:#8c93a6"></i><i style="--shade:#b8c0d9"></i><i style="--shade:#d8e2ff"></i><i style="--shade:#e0e8ff"></i><i style="--shade:#e8eeff"></i><i style="--shade:#eff3ff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #adc6ff; color: #000000;">
+        <span>secondary-fixed-dim</span>
+        <span>#ADC6FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#2b3240"></i><i style="--shade:#4e5973"></i><i style="--shade:#7081a6"></i><i style="--shade:#93a8d9"></i><i style="--shade:#adc6ff"></i><i style="--shade:#bdd1ff"></i><i style="--shade:#ceddff"></i><i style="--shade:#dee8ff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #f9f9ff; color: #000000;">
+        <span>surface</span>
+        <span>#F9F9FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#3e3e40"></i><i style="--shade:#707073"></i><i style="--shade:#a2a2a6"></i><i style="--shade:#d4d4d9"></i><i style="--shade:#f9f9ff"></i><i style="--shade:#fafaff"></i><i style="--shade:#fbfbff"></i><i style="--shade:#fdfdff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #f9f9ff; color: #000000;">
+        <span>surface-bright</span>
+        <span>#F9F9FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#3e3e40"></i><i style="--shade:#707073"></i><i style="--shade:#a2a2a6"></i><i style="--shade:#d4d4d9"></i><i style="--shade:#f9f9ff"></i><i style="--shade:#fafaff"></i><i style="--shade:#fbfbff"></i><i style="--shade:#fdfdff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #e7eefe; color: #000000;">
+        <span>surface-container</span>
+        <span>#E7EEFE</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#3a3c40"></i><i style="--shade:#686b72"></i><i style="--shade:#969ba5"></i><i style="--shade:#c4cad8"></i><i style="--shade:#e7eefe"></i><i style="--shade:#ecf1fe"></i><i style="--shade:#f1f5fe"></i><i style="--shade:#f5f8ff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #e2e8f8; color: #000000;">
+        <span>surface-container-high</span>
+        <span>#E2E8F8</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#393a3e"></i><i style="--shade:#666870"></i><i style="--shade:#9397a1"></i><i style="--shade:#c0c5d3"></i><i style="--shade:#e2e8f8"></i><i style="--shade:#e8edf9"></i><i style="--shade:#eef1fb"></i><i style="--shade:#f3f6fc"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #dce2f3; color: #000000;">
+        <span>surface-container-highest</span>
+        <span>#DCE2F3</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#37393d"></i><i style="--shade:#63666d"></i><i style="--shade:#8f939e"></i><i style="--shade:#bbc0cf"></i><i style="--shade:#dce2f3"></i><i style="--shade:#e3e8f5"></i><i style="--shade:#eaeef8"></i><i style="--shade:#f1f3fa"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #f0f3ff; color: #000000;">
+        <span>surface-container-low</span>
+        <span>#F0F3FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#3c3d40"></i><i style="--shade:#6c6d73"></i><i style="--shade:#9c9ea6"></i><i style="--shade:#cccfd9"></i><i style="--shade:#f0f3ff"></i><i style="--shade:#f3f5ff"></i><i style="--shade:#f6f8ff"></i><i style="--shade:#f9faff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffffff; color: #000000;">
+        <span>surface-container-lowest</span>
+        <span>#FFFFFF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#404040"></i><i style="--shade:#737373"></i><i style="--shade:#a6a6a6"></i><i style="--shade:#d9d9d9"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i><i style="--shade:#ffffff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #d3daea; color: #000000;">
+        <span>surface-dim</span>
+        <span>#D3DAEA</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#35373b"></i><i style="--shade:#5f6269"></i><i style="--shade:#898e98"></i><i style="--shade:#b3b9c7"></i><i style="--shade:#d3daea"></i><i style="--shade:#dce1ee"></i><i style="--shade:#e5e9f2"></i><i style="--shade:#edf0f7"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #855300; color: #ffffff;">
+        <span>surface-tint</span>
+        <span>#855300</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#211500"></i><i style="--shade:#3c2500"></i><i style="--shade:#563600"></i><i style="--shade:#714700"></i><i style="--shade:#855300"></i><i style="--shade:#9d7533"></i><i style="--shade:#b69866"></i><i style="--shade:#ceba99"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #dce2f3; color: #000000;">
+        <span>surface-variant</span>
+        <span>#DCE2F3</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#37393d"></i><i style="--shade:#63666d"></i><i style="--shade:#8f939e"></i><i style="--shade:#bbc0cf"></i><i style="--shade:#dce2f3"></i><i style="--shade:#e3e8f5"></i><i style="--shade:#eaeef8"></i><i style="--shade:#f1f3fa"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #00658b; color: #ffffff;">
+        <span>tertiary</span>
+        <span>#00658B</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#001923"></i><i style="--shade:#002d3f"></i><i style="--shade:#00425a"></i><i style="--shade:#005676"></i><i style="--shade:#00658b"></i><i style="--shade:#3384a2"></i><i style="--shade:#66a3b9"></i><i style="--shade:#99c1d1"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #1abdff; color: #000000;">
+        <span>tertiary-container</span>
+        <span>#1ABDFF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#072f40"></i><i style="--shade:#0c5573"></i><i style="--shade:#117ba6"></i><i style="--shade:#16a1d9"></i><i style="--shade:#1abdff"></i><i style="--shade:#48caff"></i><i style="--shade:#76d7ff"></i><i style="--shade:#a3e5ff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #c5e7ff; color: #000000;">
+        <span>tertiary-fixed</span>
+        <span>#C5E7FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#313a40"></i><i style="--shade:#596873"></i><i style="--shade:#8096a6"></i><i style="--shade:#a7c4d9"></i><i style="--shade:#c5e7ff"></i><i style="--shade:#d1ecff"></i><i style="--shade:#dcf1ff"></i><i style="--shade:#e8f5ff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #7fd0ff; color: #000000;">
+        <span>tertiary-fixed-dim</span>
+        <span>#7FD0FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#203440"></i><i style="--shade:#395e73"></i><i style="--shade:#5387a6"></i><i style="--shade:#6cb1d9"></i><i style="--shade:#7fd0ff"></i><i style="--shade:#99d9ff"></i><i style="--shade:#b2e3ff"></i><i style="--shade:#ccecff"></i>
+      </div>
+    </article>
+        </div>
+      </div>
+
+      <!-- TYPOGRAPHY TAB -->
+      <div id="tab-typography" class="tab-content">
+        <div class="grid-auto">
+          <article class="card">
+        <div class="type-header">
+          <span>body-lg</span>
+          <span>Plus Jakarta Sans</span>
+        </div>
+        <p class="type-sample" style="font-family:Plus Jakarta Sans;font-size: 6.5rem;font-weight:400">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>body-md</span>
+          <span>Plus Jakarta Sans</span>
+        </div>
+        <p class="type-sample" style="font-family:Plus Jakarta Sans;font-size: 6.5rem;font-weight:400">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>display</span>
+          <span>Plus Jakarta Sans</span>
+        </div>
+        <p class="type-sample" style="font-family:Plus Jakarta Sans;font-size: 6.5rem;font-weight:800;letter-spacing:-0.02em">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>headline-lg</span>
+          <span>Plus Jakarta Sans</span>
+        </div>
+        <p class="type-sample" style="font-family:Plus Jakarta Sans;font-size: 6.5rem;font-weight:700;letter-spacing:-0.01em">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>headline-md</span>
+          <span>Plus Jakarta Sans</span>
+        </div>
+        <p class="type-sample" style="font-family:Plus Jakarta Sans;font-size: 6.5rem;font-weight:700">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>label-md</span>
+          <span>Plus Jakarta Sans</span>
+        </div>
+        <p class="type-sample" style="font-family:Plus Jakarta Sans;font-size: 6.5rem;font-weight:600;letter-spacing:0.01em">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>label-sm</span>
+          <span>Plus Jakarta Sans</span>
+        </div>
+        <p class="type-sample" style="font-family:Plus Jakarta Sans;font-size: 6.5rem;font-weight:500">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>title-lg</span>
+          <span>Plus Jakarta Sans</span>
+        </div>
+        <p class="type-sample" style="font-family:Plus Jakarta Sans;font-size: 6.5rem;font-weight:600">Aa</p>
+      </article>
+        </div>
+      </div>
+
+      <!-- LAYOUT (SPACING) TAB -->
+      <div id="tab-layout" class="tab-content">
+        <div class="masonry">
+          <div class="card">
+            <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">All Spacing Tokens</h3>
+            <div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">base</strong>
+          <span style="color:var(--text-muted);">8px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:17.6px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">gutter</strong>
+          <span style="color:var(--text-muted);">16px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:35.2px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">lg</strong>
+          <span style="color:var(--text-muted);">40px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:88px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">margin</strong>
+          <span style="color:var(--text-muted);">24px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:52.800000000000004px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">md</strong>
+          <span style="color:var(--text-muted);">24px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:52.800000000000004px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">sm</strong>
+          <span style="color:var(--text-muted);">12px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:26.400000000000002px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">xl</strong>
+          <span style="color:var(--text-muted);">64px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:140.8px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">xs</strong>
+          <span style="color:var(--text-muted);">4px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:12px"></i></div>
+      </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- SHAPES (ROUNDED) TAB -->
+      <div id="tab-shapes" class="tab-content">
+        <div class="masonry">
+          <div class="card">
+            <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">All Rounded Tokens</h3>
+            <div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">DEFAULT</strong>
+          <span style="color:var(--text-muted);">0.5rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.5rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">full</strong>
+          <span style="color:var(--text-muted);">9999px</span>
+        </div>
+        <div class="rounded-chip" style="--radius:9999px"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">lg</strong>
+          <span style="color:var(--text-muted);">1rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:1rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">md</strong>
+          <span style="color:var(--text-muted);">0.75rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.75rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">sm</strong>
+          <span style="color:var(--text-muted);">0.25rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.25rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">xl</strong>
+          <span style="color:var(--text-muted);">1.5rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:1.5rem"></div>
+      </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- COMPONENTS TAB -->
+      <div id="tab-components" class="tab-content">
+        <div class="masonry">
+          <article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">badge-status</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#1abdff</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>4px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>9999px</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#004966</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Plus Jakarta Sans 12px/16px (500)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-primary</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#855300</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>24px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>1rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#ffffff</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Plus Jakarta Sans 14px/20px (600)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-primary-hover</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#f59e0b</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#613b00</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-secondary</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#0058be</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>24px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>1rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#ffffff</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Plus Jakarta Sans 14px/20px (600)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-secondary-hover</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#2170e4</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#fefcff</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">card-profile</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#ffffff</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>24px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>1.5rem</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">card-walk-stat</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#2170e4</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>12px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>0.75rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#fefcff</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">input-field</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#f0f3ff</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>12px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>0.5rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#151c27</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Plus Jakarta Sans 16px/24px (400)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">list-item-walker</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>transparent</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>12px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>0.75rem</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">list-item-walker-hover</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#e2e8f8</span>
+      </div>
+      </div>
+    </article>
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+  <script>
+    function showTab(event, tabId) {
+      document.querySelectorAll('.tab-content').forEach(el => el.classList.remove('active'));
+      document.querySelectorAll('.tab-btn').forEach(el => el.classList.remove('active'));
+      
+      document.getElementById(tabId).classList.add('active');
+      event.currentTarget.classList.add('active');
+    }
+  </script>
+</body>
+</html>

--- a/examples/totality-festival/preview.html
+++ b/examples/totality-festival/preview.html
@@ -1,0 +1,1201 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Totality Festival Design System - DESIGN.md Show</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&family=Noto+Serif:wght@400;700&display=swap');
+
+    :root {
+      --bg-dark: #242424;
+      --board-bg: #e2e2db;
+      --board-border: #7951ff;
+      --card-bg: #f5f5f0;
+      --text-main: #333333;
+      --text-muted: #888888;
+      --radius-xl: 1.5rem;
+      --radius-lg: 1rem;
+      --radius-md: 0.75rem;
+      --radius-sm: 0.5rem;
+      --radius-pill: 9999px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "Manrope", sans-serif;
+      color: var(--text-main);
+      background-color: var(--bg-dark);
+      background-image: radial-gradient(#3a3a3a 1px, transparent 0);
+      background-size: 20px 20px;
+      padding: 2rem 4rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .page-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      color: white;
+      padding: 0 1rem;
+    }
+
+    .page-title {
+      font-weight: 700;
+      font-size: 1.25rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    
+    .page-title svg {
+      width: 24px;
+      height: 24px;
+      fill: currentColor;
+    }
+
+    .page-actions {
+      display: flex;
+      gap: 0.5rem;
+      color: #999;
+    }
+
+    .page-actions svg {
+      width: 24px;
+      height: 24px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 2;
+    }
+
+    .board-container {
+      border: 4px solid var(--board-border);
+      border-radius: var(--radius-xl);
+      background: var(--board-bg);
+      padding: 1.5rem;
+      box-shadow: 0 24px 48px rgba(0,0,0,0.2);
+    }
+
+    .tabs {
+      display: flex;
+      gap: 1.5rem;
+      margin-bottom: 1.5rem;
+      border-bottom: 2px solid rgba(0,0,0,0.05);
+      padding-bottom: 0.5rem;
+    }
+
+    .tab-btn {
+      background: none;
+      border: none;
+      color: var(--text-muted);
+      font-family: "Manrope", sans-serif;
+      font-weight: 700;
+      font-size: 1rem;
+      cursor: pointer;
+      padding: 0.5rem 0.25rem;
+      border-bottom: 3px solid transparent;
+      margin-bottom: -0.5rem;
+      transition: color 0.2s, border-color 0.2s;
+    }
+
+    .tab-btn:hover {
+      color: var(--text-main);
+    }
+
+    .tab-btn.active {
+      color: var(--text-main);
+      border-bottom-color: var(--board-border);
+    }
+
+    .tab-content {
+      display: none;
+      animation: fadeIn 0.3s ease;
+    }
+
+    .tab-content.active {
+      display: block;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(5px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    /* Column layouts for Overview */
+    .grid-4 {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 1.5rem;
+      align-items: start;
+    }
+
+    .column {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    /* Masonry layout for inner tabs */
+    .masonry {
+      column-count: 4;
+      column-gap: 1.5rem;
+    }
+    .masonry > * {
+      break-inside: avoid;
+      margin-bottom: 1.5rem;
+    }
+    
+    .grid-auto {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 1.5rem;
+      align-items: start;
+    }
+
+    /* Cards */
+    .card {
+      background: var(--card-bg);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+      padding: 1.25rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    /* Color Card */
+    .color-card {
+      padding: 0;
+      gap: 0;
+    }
+    .color-main {
+      padding: 1.25rem;
+      display: flex;
+      justify-content: space-between;
+      font-weight: 700;
+      font-size: 0.9rem;
+      min-height: 120px;
+    }
+    .color-shades {
+      display: flex;
+      height: 36px;
+    }
+    .color-shades i {
+      flex: 1;
+      background: var(--shade);
+    }
+
+    /* Typography Card */
+    .type-header {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin-bottom: 2.5rem;
+    }
+    .type-sample {
+      margin: 0;
+      text-align: center;
+      font-size: 6.5rem;
+      line-height: 1;
+      color: #333;
+      padding-bottom: 1.5rem;
+    }
+
+    /* Dimension Rows */
+    .dim-row {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 0.5rem;
+      font-size: 0.85rem;
+      margin-bottom: 0.5rem;
+      align-items: center;
+    }
+    .dim-bar {
+      grid-column: 1 / -1;
+      height: 6px;
+      border-radius: var(--radius-pill);
+      background: rgba(0,0,0,0.05);
+      margin-bottom: 1rem;
+    }
+    .dim-bar i {
+      display: block;
+      height: 100%;
+      border-radius: var(--radius-pill);
+      background: #5d665b;
+      width: var(--width);
+    }
+    .rounded-chip {
+      height: 32px;
+      background: rgba(0,0,0,0.1);
+      border-radius: var(--radius);
+      margin-top: 0.25rem;
+    }
+
+    /* Components */
+    .component-prop {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.85rem;
+      padding: 0.35rem 0;
+      border-bottom: 1px solid rgba(0,0,0,0.05);
+    }
+    .component-prop:last-child {
+      border-bottom: none;
+    }
+    .component-prop strong {
+      color: var(--text-muted);
+      font-weight: 400;
+    }
+
+    .diagnostics {
+      margin-bottom: 1rem;
+      border-radius: var(--radius-md);
+      padding: 1rem;
+      background: #ffebee;
+      color: #c62828;
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 1200px) {
+      .grid { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (max-width: 768px) {
+      .grid { grid-template-columns: 1fr; }
+      body { padding: 1rem; }
+    }
+  </style>
+</head>
+<body>
+  <header class="page-header">
+    <div class="page-title">
+      <svg viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/></svg>
+      Totality Festival Design System
+    </div>
+    <div class="page-actions">
+      <svg viewBox="0 0 24 24"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon></svg>
+      <svg viewBox="0 0 24 24"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"></path></svg>
+      <svg viewBox="0 0 24 24"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h3a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2h-3"></path></svg>
+    </div>
+  </header>
+
+  <div class="board-container">
+    <div class="diagnostics">
+    <p style="margin:0 0 0.5rem;font-weight:bold;">Diagnostics: 0 errors, 38 warnings</p>
+    <ul style="margin:0;padding-left:1.5rem;"><li>[colors.surface] &#39;surface&#39; is defined but never referenced by any component.</li><li>[colors.surface-dim] &#39;surface-dim&#39; is defined but never referenced by any component.</li><li>[colors.surface-bright] &#39;surface-bright&#39; is defined but never referenced by any component.</li><li>[colors.surface-container-low] &#39;surface-container-low&#39; is defined but never referenced by any component.</li><li>[colors.surface-container] &#39;surface-container&#39; is defined but never referenced by any component.</li><li>[colors.surface-container-highest] &#39;surface-container-highest&#39; is defined but never referenced by any component.</li></ul>
+  </div>
+    
+    <nav class="tabs">
+      <button class="tab-btn active" onclick="showTab(event, 'tab-overview')">Overview</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-colors')">Colors (47)</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-typography')">Typography (6)</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-layout')">Layout (5)</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-shapes')">Shapes (6)</button>
+      <button class="tab-btn" onclick="showTab(event, 'tab-components')">Components (10)</button>
+    </nav>
+
+    <main class="board">
+      
+      <!-- OVERVIEW TAB -->
+      <div id="tab-overview" class="tab-content active">
+        <div class="grid-4">
+          <div class="column">
+            <article class="card color-card">
+      <div class="color-main" style="background-color: #121318; color: #ffffff;">
+        <span>background</span>
+        <span>#121318</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#050506"></i><i style="--shade:#08090b"></i><i style="--shade:#0c0c10"></i><i style="--shade:#0f1014"></i><i style="--shade:#121318"></i><i style="--shade:#414246"></i><i style="--shade:#717174"></i><i style="--shade:#a0a1a3"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffb4ab; color: #000000;">
+        <span>error</span>
+        <span>#FFB4AB</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#402d2b"></i><i style="--shade:#73514d"></i><i style="--shade:#a6756f"></i><i style="--shade:#d99991"></i><i style="--shade:#ffb4ab"></i><i style="--shade:#ffc3bc"></i><i style="--shade:#ffd2cd"></i><i style="--shade:#ffe1dd"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #93000a; color: #ffffff;">
+        <span>error-container</span>
+        <span>#93000A</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#250003"></i><i style="--shade:#420005"></i><i style="--shade:#600007"></i><i style="--shade:#7d0009"></i><i style="--shade:#93000a"></i><i style="--shade:#a9333b"></i><i style="--shade:#be666c"></i><i style="--shade:#d4999d"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #2f3036; color: #ffffff;">
+        <span>inverse-on-surface</span>
+        <span>#2F3036</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0c0c0e"></i><i style="--shade:#151618"></i><i style="--shade:#1f1f23"></i><i style="--shade:#28292e"></i><i style="--shade:#2f3036"></i><i style="--shade:#59595e"></i><i style="--shade:#828386"></i><i style="--shade:#acacaf"></i>
+      </div>
+    </article>
+          </div>
+          <div class="column">
+            <article class="card">
+        <div class="type-header">
+          <span>body-lg</span>
+          <span>Inter</span>
+        </div>
+        <p class="type-sample" style="font-family:Inter;font-size: 6.5rem;font-weight:400;letter-spacing:0em">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>body-md</span>
+          <span>Inter</span>
+        </div>
+        <p class="type-sample" style="font-family:Inter;font-size: 6.5rem;font-weight:400;letter-spacing:0em">Aa</p>
+      </article>
+          </div>
+          <div class="column">
+            <div class="card">
+              <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">Spacing</h3>
+              <div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">container-max</strong>
+          <span style="color:var(--text-muted);">1280px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:240px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">gutter</strong>
+          <span style="color:var(--text-muted);">24px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:52.800000000000004px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">margin-desktop</strong>
+          <span style="color:var(--text-muted);">64px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:140.8px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">margin-mobile</strong>
+          <span style="color:var(--text-muted);">16px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:35.2px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">unit</strong>
+          <span style="color:var(--text-muted);">8px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:17.6px"></i></div>
+      </div>
+            </div>
+            <article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">badge-celestial</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#e7d1ff</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>4px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>9999px</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#6b5586</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Space Grotesk 14px/20px (500)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-primary</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#fff6df</span>
+      </div><div class="component-prop">
+        <strong>height</strong>
+        <span>48px</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>12px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>0.5rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#3a3000</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Space Grotesk 14px/20px (500)</span>
+      </div>
+      </div>
+    </article>
+          </div>
+          <div class="column">
+            <div class="card">
+              <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">Rounded</h3>
+              <div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">DEFAULT</strong>
+          <span style="color:var(--text-muted);">0.25rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.25rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">full</strong>
+          <span style="color:var(--text-muted);">9999px</span>
+        </div>
+        <div class="rounded-chip" style="--radius:9999px"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">lg</strong>
+          <span style="color:var(--text-muted);">0.5rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.5rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">md</strong>
+          <span style="color:var(--text-muted);">0.375rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.375rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">sm</strong>
+          <span style="color:var(--text-muted);">0.125rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.125rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">xl</strong>
+          <span style="color:var(--text-muted);">0.75rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.75rem"></div>
+      </div>
+            </div>
+            <article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-primary-hover</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#ffe16d</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-secondary</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>transparent</span>
+      </div><div class="component-prop">
+        <strong>height</strong>
+        <span>48px</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>12px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>0.5rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#bdf4ff</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Space Grotesk 14px/20px (500)</span>
+      </div>
+      </div>
+    </article>
+          </div>
+        </div>
+      </div>
+
+      <!-- COLORS TAB -->
+      <div id="tab-colors" class="tab-content">
+        <div class="grid-auto">
+          <article class="card color-card">
+      <div class="color-main" style="background-color: #121318; color: #ffffff;">
+        <span>background</span>
+        <span>#121318</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#050506"></i><i style="--shade:#08090b"></i><i style="--shade:#0c0c10"></i><i style="--shade:#0f1014"></i><i style="--shade:#121318"></i><i style="--shade:#414246"></i><i style="--shade:#717174"></i><i style="--shade:#a0a1a3"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffb4ab; color: #000000;">
+        <span>error</span>
+        <span>#FFB4AB</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#402d2b"></i><i style="--shade:#73514d"></i><i style="--shade:#a6756f"></i><i style="--shade:#d99991"></i><i style="--shade:#ffb4ab"></i><i style="--shade:#ffc3bc"></i><i style="--shade:#ffd2cd"></i><i style="--shade:#ffe1dd"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #93000a; color: #ffffff;">
+        <span>error-container</span>
+        <span>#93000A</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#250003"></i><i style="--shade:#420005"></i><i style="--shade:#600007"></i><i style="--shade:#7d0009"></i><i style="--shade:#93000a"></i><i style="--shade:#a9333b"></i><i style="--shade:#be666c"></i><i style="--shade:#d4999d"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #2f3036; color: #ffffff;">
+        <span>inverse-on-surface</span>
+        <span>#2F3036</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0c0c0e"></i><i style="--shade:#151618"></i><i style="--shade:#1f1f23"></i><i style="--shade:#28292e"></i><i style="--shade:#2f3036"></i><i style="--shade:#59595e"></i><i style="--shade:#828386"></i><i style="--shade:#acacaf"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #705d00; color: #ffffff;">
+        <span>inverse-primary</span>
+        <span>#705D00</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#1c1700"></i><i style="--shade:#322a00"></i><i style="--shade:#493c00"></i><i style="--shade:#5f4f00"></i><i style="--shade:#705d00"></i><i style="--shade:#8d7d33"></i><i style="--shade:#a99e66"></i><i style="--shade:#c6be99"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #e3e1e9; color: #000000;">
+        <span>inverse-surface</span>
+        <span>#E3E1E9</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#39383a"></i><i style="--shade:#666569"></i><i style="--shade:#949297"></i><i style="--shade:#c1bfc6"></i><i style="--shade:#e3e1e9"></i><i style="--shade:#e9e7ed"></i><i style="--shade:#eeedf2"></i><i style="--shade:#f4f3f6"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #e3e1e9; color: #000000;">
+        <span>on-background</span>
+        <span>#E3E1E9</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#39383a"></i><i style="--shade:#666569"></i><i style="--shade:#949297"></i><i style="--shade:#c1bfc6"></i><i style="--shade:#e3e1e9"></i><i style="--shade:#e9e7ed"></i><i style="--shade:#eeedf2"></i><i style="--shade:#f4f3f6"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #690005; color: #ffffff;">
+        <span>on-error</span>
+        <span>#690005</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#1a0001"></i><i style="--shade:#2f0002"></i><i style="--shade:#440003"></i><i style="--shade:#590004"></i><i style="--shade:#690005"></i><i style="--shade:#873337"></i><i style="--shade:#a56669"></i><i style="--shade:#c3999b"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffdad6; color: #000000;">
+        <span>on-error-container</span>
+        <span>#FFDAD6</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#403736"></i><i style="--shade:#736260"></i><i style="--shade:#a68e8b"></i><i style="--shade:#d9b9b6"></i><i style="--shade:#ffdad6"></i><i style="--shade:#ffe1de"></i><i style="--shade:#ffe9e6"></i><i style="--shade:#fff0ef"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #3a3000; color: #ffffff;">
+        <span>on-primary</span>
+        <span>#3A3000</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0f0c00"></i><i style="--shade:#1a1600"></i><i style="--shade:#261f00"></i><i style="--shade:#312900"></i><i style="--shade:#3a3000"></i><i style="--shade:#615933"></i><i style="--shade:#898366"></i><i style="--shade:#b0ac99"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #705e00; color: #ffffff;">
+        <span>on-primary-container</span>
+        <span>#705E00</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#1c1800"></i><i style="--shade:#322a00"></i><i style="--shade:#493d00"></i><i style="--shade:#5f5000"></i><i style="--shade:#705e00"></i><i style="--shade:#8d7e33"></i><i style="--shade:#a99e66"></i><i style="--shade:#c6bf99"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #221b00; color: #ffffff;">
+        <span>on-primary-fixed</span>
+        <span>#221B00</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#090700"></i><i style="--shade:#0f0c00"></i><i style="--shade:#161200"></i><i style="--shade:#1d1700"></i><i style="--shade:#221b00"></i><i style="--shade:#4e4933"></i><i style="--shade:#7a7666"></i><i style="--shade:#a7a499"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #544600; color: #ffffff;">
+        <span>on-primary-fixed-variant</span>
+        <span>#544600</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#151200"></i><i style="--shade:#261f00"></i><i style="--shade:#372e00"></i><i style="--shade:#473c00"></i><i style="--shade:#544600"></i><i style="--shade:#766b33"></i><i style="--shade:#989066"></i><i style="--shade:#bbb599"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #00363d; color: #ffffff;">
+        <span>on-secondary</span>
+        <span>#00363D</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#000e0f"></i><i style="--shade:#00181b"></i><i style="--shade:#002328"></i><i style="--shade:#002e34"></i><i style="--shade:#00363d"></i><i style="--shade:#335e64"></i><i style="--shade:#66868b"></i><i style="--shade:#99afb1"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #00616d; color: #ffffff;">
+        <span>on-secondary-container</span>
+        <span>#00616D</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#00181b"></i><i style="--shade:#002c31"></i><i style="--shade:#003f47"></i><i style="--shade:#00525d"></i><i style="--shade:#00616d"></i><i style="--shade:#33818a"></i><i style="--shade:#66a0a7"></i><i style="--shade:#99c0c5"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #001f24; color: #ffffff;">
+        <span>on-secondary-fixed</span>
+        <span>#001F24</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#000809"></i><i style="--shade:#000e10"></i><i style="--shade:#001417"></i><i style="--shade:#001a1f"></i><i style="--shade:#001f24"></i><i style="--shade:#334c50"></i><i style="--shade:#66797c"></i><i style="--shade:#99a5a7"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #004f58; color: #ffffff;">
+        <span>on-secondary-fixed-variant</span>
+        <span>#004F58</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#001416"></i><i style="--shade:#002428"></i><i style="--shade:#003339"></i><i style="--shade:#00434b"></i><i style="--shade:#004f58"></i><i style="--shade:#337279"></i><i style="--shade:#66959b"></i><i style="--shade:#99b9bc"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #e3e1e9; color: #000000;">
+        <span>on-surface</span>
+        <span>#E3E1E9</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#39383a"></i><i style="--shade:#666569"></i><i style="--shade:#949297"></i><i style="--shade:#c1bfc6"></i><i style="--shade:#e3e1e9"></i><i style="--shade:#e9e7ed"></i><i style="--shade:#eeedf2"></i><i style="--shade:#f4f3f6"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #d0c6ab; color: #000000;">
+        <span>on-surface-variant</span>
+        <span>#D0C6AB</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#34322b"></i><i style="--shade:#5e594d"></i><i style="--shade:#87816f"></i><i style="--shade:#b1a891"></i><i style="--shade:#d0c6ab"></i><i style="--shade:#d9d1bc"></i><i style="--shade:#e3ddcd"></i><i style="--shade:#ece8dd"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #3b2754; color: #ffffff;">
+        <span>on-tertiary</span>
+        <span>#3B2754</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0f0a15"></i><i style="--shade:#1b1226"></i><i style="--shade:#261937"></i><i style="--shade:#322147"></i><i style="--shade:#3b2754"></i><i style="--shade:#625276"></i><i style="--shade:#897d98"></i><i style="--shade:#b1a9bb"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #6b5586; color: #ffffff;">
+        <span>on-tertiary-container</span>
+        <span>#6B5586</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#1b1522"></i><i style="--shade:#30263c"></i><i style="--shade:#463757"></i><i style="--shade:#5b4872"></i><i style="--shade:#6b5586"></i><i style="--shade:#89779e"></i><i style="--shade:#a699b6"></i><i style="--shade:#c4bbcf"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #25113e; color: #ffffff;">
+        <span>on-tertiary-fixed</span>
+        <span>#25113E</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#090410"></i><i style="--shade:#11081c"></i><i style="--shade:#180b28"></i><i style="--shade:#1f0e35"></i><i style="--shade:#25113e"></i><i style="--shade:#514165"></i><i style="--shade:#7c708b"></i><i style="--shade:#a8a0b2"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #523d6c; color: #ffffff;">
+        <span>on-tertiary-fixed-variant</span>
+        <span>#523D6C</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#150f1b"></i><i style="--shade:#251b31"></i><i style="--shade:#352846"></i><i style="--shade:#46345c"></i><i style="--shade:#523d6c"></i><i style="--shade:#756489"></i><i style="--shade:#978ba7"></i><i style="--shade:#bab1c4"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #999077; color: #ffffff;">
+        <span>outline</span>
+        <span>#999077</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#26241e"></i><i style="--shade:#454136"></i><i style="--shade:#635e4d"></i><i style="--shade:#827a65"></i><i style="--shade:#999077"></i><i style="--shade:#ada692"></i><i style="--shade:#c2bcad"></i><i style="--shade:#d6d3c9"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #4d4732; color: #ffffff;">
+        <span>outline-variant</span>
+        <span>#4D4732</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#13120d"></i><i style="--shade:#232016"></i><i style="--shade:#322e21"></i><i style="--shade:#413c2b"></i><i style="--shade:#4d4732"></i><i style="--shade:#716c5b"></i><i style="--shade:#949184"></i><i style="--shade:#b8b5ad"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #fff6df; color: #000000;">
+        <span>primary</span>
+        <span>#FFF6DF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#403e38"></i><i style="--shade:#736f64"></i><i style="--shade:#a6a091"></i><i style="--shade:#d9d1be"></i><i style="--shade:#fff6df"></i><i style="--shade:#fff8e5"></i><i style="--shade:#fffaec"></i><i style="--shade:#fffbf2"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffd700; color: #000000;">
+        <span>primary-container</span>
+        <span>#FFD700</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#403600"></i><i style="--shade:#736100"></i><i style="--shade:#a68c00"></i><i style="--shade:#d9b700"></i><i style="--shade:#ffd700"></i><i style="--shade:#ffdf33"></i><i style="--shade:#ffe766"></i><i style="--shade:#ffef99"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #ffe16d; color: #000000;">
+        <span>primary-fixed</span>
+        <span>#FFE16D</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#40381b"></i><i style="--shade:#736531"></i><i style="--shade:#a69247"></i><i style="--shade:#d9bf5d"></i><i style="--shade:#ffe16d"></i><i style="--shade:#ffe78a"></i><i style="--shade:#ffeda7"></i><i style="--shade:#fff3c5"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #e9c400; color: #000000;">
+        <span>primary-fixed-dim</span>
+        <span>#E9C400</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#3a3100"></i><i style="--shade:#695800"></i><i style="--shade:#977f00"></i><i style="--shade:#c6a700"></i><i style="--shade:#e9c400"></i><i style="--shade:#edd033"></i><i style="--shade:#f2dc66"></i><i style="--shade:#f6e799"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #bdf4ff; color: #000000;">
+        <span>secondary</span>
+        <span>#BDF4FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#2f3d40"></i><i style="--shade:#556e73"></i><i style="--shade:#7b9fa6"></i><i style="--shade:#a1cfd9"></i><i style="--shade:#bdf4ff"></i><i style="--shade:#caf6ff"></i><i style="--shade:#d7f8ff"></i><i style="--shade:#e5fbff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #00e3fd; color: #000000;">
+        <span>secondary-container</span>
+        <span>#00E3FD</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#00393f"></i><i style="--shade:#006672"></i><i style="--shade:#0094a4"></i><i style="--shade:#00c1d7"></i><i style="--shade:#00e3fd"></i><i style="--shade:#33e9fd"></i><i style="--shade:#66eefe"></i><i style="--shade:#99f4fe"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #9cf0ff; color: #000000;">
+        <span>secondary-fixed</span>
+        <span>#9CF0FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#273c40"></i><i style="--shade:#466c73"></i><i style="--shade:#659ca6"></i><i style="--shade:#85ccd9"></i><i style="--shade:#9cf0ff"></i><i style="--shade:#b0f3ff"></i><i style="--shade:#c4f6ff"></i><i style="--shade:#d7f9ff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #00daf3; color: #000000;">
+        <span>secondary-fixed-dim</span>
+        <span>#00DAF3</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#00373d"></i><i style="--shade:#00626d"></i><i style="--shade:#008e9e"></i><i style="--shade:#00b9cf"></i><i style="--shade:#00daf3"></i><i style="--shade:#33e1f5"></i><i style="--shade:#66e9f8"></i><i style="--shade:#99f0fa"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #121318; color: #ffffff;">
+        <span>surface</span>
+        <span>#121318</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#050506"></i><i style="--shade:#08090b"></i><i style="--shade:#0c0c10"></i><i style="--shade:#0f1014"></i><i style="--shade:#121318"></i><i style="--shade:#414246"></i><i style="--shade:#717174"></i><i style="--shade:#a0a1a3"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #38393f; color: #ffffff;">
+        <span>surface-bright</span>
+        <span>#38393F</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0e0e10"></i><i style="--shade:#191a1c"></i><i style="--shade:#242529"></i><i style="--shade:#303036"></i><i style="--shade:#38393f"></i><i style="--shade:#606165"></i><i style="--shade:#88888c"></i><i style="--shade:#afb0b2"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #1e1f25; color: #ffffff;">
+        <span>surface-container</span>
+        <span>#1E1F25</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#080809"></i><i style="--shade:#0d0e11"></i><i style="--shade:#141418"></i><i style="--shade:#1a1a1f"></i><i style="--shade:#1e1f25"></i><i style="--shade:#4b4c51"></i><i style="--shade:#78797c"></i><i style="--shade:#a5a5a8"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #292a2f; color: #ffffff;">
+        <span>surface-container-high</span>
+        <span>#292A2F</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0a0b0c"></i><i style="--shade:#121315"></i><i style="--shade:#1b1b1f"></i><i style="--shade:#232428"></i><i style="--shade:#292a2f"></i><i style="--shade:#545559"></i><i style="--shade:#7f7f82"></i><i style="--shade:#a9aaac"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #34343a; color: #ffffff;">
+        <span>surface-container-highest</span>
+        <span>#34343A</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0d0d0f"></i><i style="--shade:#17171a"></i><i style="--shade:#222226"></i><i style="--shade:#2c2c31"></i><i style="--shade:#34343a"></i><i style="--shade:#5d5d61"></i><i style="--shade:#858589"></i><i style="--shade:#aeaeb0"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #1a1b21; color: #ffffff;">
+        <span>surface-container-low</span>
+        <span>#1A1B21</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#070708"></i><i style="--shade:#0c0c0f"></i><i style="--shade:#111215"></i><i style="--shade:#16171c"></i><i style="--shade:#1a1b21"></i><i style="--shade:#48494d"></i><i style="--shade:#76767a"></i><i style="--shade:#a3a4a6"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #0d0e13; color: #ffffff;">
+        <span>surface-container-lowest</span>
+        <span>#0D0E13</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#030405"></i><i style="--shade:#060609"></i><i style="--shade:#08090c"></i><i style="--shade:#0b0c10"></i><i style="--shade:#0d0e13"></i><i style="--shade:#3d3e42"></i><i style="--shade:#6e6e71"></i><i style="--shade:#9e9fa1"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #121318; color: #ffffff;">
+        <span>surface-dim</span>
+        <span>#121318</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#050506"></i><i style="--shade:#08090b"></i><i style="--shade:#0c0c10"></i><i style="--shade:#0f1014"></i><i style="--shade:#121318"></i><i style="--shade:#414246"></i><i style="--shade:#717174"></i><i style="--shade:#a0a1a3"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #e9c400; color: #000000;">
+        <span>surface-tint</span>
+        <span>#E9C400</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#3a3100"></i><i style="--shade:#695800"></i><i style="--shade:#977f00"></i><i style="--shade:#c6a700"></i><i style="--shade:#e9c400"></i><i style="--shade:#edd033"></i><i style="--shade:#f2dc66"></i><i style="--shade:#f6e799"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #34343a; color: #ffffff;">
+        <span>surface-variant</span>
+        <span>#34343A</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#0d0d0f"></i><i style="--shade:#17171a"></i><i style="--shade:#222226"></i><i style="--shade:#2c2c31"></i><i style="--shade:#34343a"></i><i style="--shade:#5d5d61"></i><i style="--shade:#858589"></i><i style="--shade:#aeaeb0"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #fcf3ff; color: #000000;">
+        <span>tertiary</span>
+        <span>#FCF3FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#3f3d40"></i><i style="--shade:#716d73"></i><i style="--shade:#a49ea6"></i><i style="--shade:#d6cfd9"></i><i style="--shade:#fcf3ff"></i><i style="--shade:#fdf5ff"></i><i style="--shade:#fdf8ff"></i><i style="--shade:#fefaff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #e7d1ff; color: #000000;">
+        <span>tertiary-container</span>
+        <span>#E7D1FF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#3a3440"></i><i style="--shade:#685e73"></i><i style="--shade:#9688a6"></i><i style="--shade:#c4b2d9"></i><i style="--shade:#e7d1ff"></i><i style="--shade:#ecdaff"></i><i style="--shade:#f1e3ff"></i><i style="--shade:#f5edff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #eedbff; color: #000000;">
+        <span>tertiary-fixed</span>
+        <span>#EEDBFF</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#3c3740"></i><i style="--shade:#6b6373"></i><i style="--shade:#9b8ea6"></i><i style="--shade:#cabad9"></i><i style="--shade:#eedbff"></i><i style="--shade:#f1e2ff"></i><i style="--shade:#f5e9ff"></i><i style="--shade:#f8f1ff"></i>
+      </div>
+    </article><article class="card color-card">
+      <div class="color-main" style="background-color: #d6bcf4; color: #000000;">
+        <span>tertiary-fixed-dim</span>
+        <span>#D6BCF4</span>
+      </div>
+      <div class="color-shades">
+        <i style="--shade:#362f3d"></i><i style="--shade:#60556e"></i><i style="--shade:#8b7a9f"></i><i style="--shade:#b6a0cf"></i><i style="--shade:#d6bcf4"></i><i style="--shade:#dec9f6"></i><i style="--shade:#e6d7f8"></i><i style="--shade:#efe4fb"></i>
+      </div>
+    </article>
+        </div>
+      </div>
+
+      <!-- TYPOGRAPHY TAB -->
+      <div id="tab-typography" class="tab-content">
+        <div class="grid-auto">
+          <article class="card">
+        <div class="type-header">
+          <span>body-lg</span>
+          <span>Inter</span>
+        </div>
+        <p class="type-sample" style="font-family:Inter;font-size: 6.5rem;font-weight:400;letter-spacing:0em">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>body-md</span>
+          <span>Inter</span>
+        </div>
+        <p class="type-sample" style="font-family:Inter;font-size: 6.5rem;font-weight:400;letter-spacing:0em">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>headline-lg</span>
+          <span>Space Grotesk</span>
+        </div>
+        <p class="type-sample" style="font-family:Space Grotesk;font-size: 6.5rem;font-weight:600;letter-spacing:-0.02em">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>headline-md</span>
+          <span>Space Grotesk</span>
+        </div>
+        <p class="type-sample" style="font-family:Space Grotesk;font-size: 6.5rem;font-weight:600;letter-spacing:0em">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>headline-xl</span>
+          <span>Space Grotesk</span>
+        </div>
+        <p class="type-sample" style="font-family:Space Grotesk;font-size: 6.5rem;font-weight:700;letter-spacing:-0.04em">Aa</p>
+      </article><article class="card">
+        <div class="type-header">
+          <span>label-md</span>
+          <span>Space Grotesk</span>
+        </div>
+        <p class="type-sample" style="font-family:Space Grotesk;font-size: 6.5rem;font-weight:500;letter-spacing:0.1em">Aa</p>
+      </article>
+        </div>
+      </div>
+
+      <!-- LAYOUT (SPACING) TAB -->
+      <div id="tab-layout" class="tab-content">
+        <div class="masonry">
+          <div class="card">
+            <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">All Spacing Tokens</h3>
+            <div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">container-max</strong>
+          <span style="color:var(--text-muted);">1280px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:240px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">gutter</strong>
+          <span style="color:var(--text-muted);">24px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:52.800000000000004px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">margin-desktop</strong>
+          <span style="color:var(--text-muted);">64px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:140.8px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">margin-mobile</strong>
+          <span style="color:var(--text-muted);">16px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:35.2px"></i></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">unit</strong>
+          <span style="color:var(--text-muted);">8px</span>
+        </div>
+        <div class="dim-bar"><i style="--width:17.6px"></i></div>
+      </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- SHAPES (ROUNDED) TAB -->
+      <div id="tab-shapes" class="tab-content">
+        <div class="masonry">
+          <div class="card">
+            <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">All Rounded Tokens</h3>
+            <div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">DEFAULT</strong>
+          <span style="color:var(--text-muted);">0.25rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.25rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">full</strong>
+          <span style="color:var(--text-muted);">9999px</span>
+        </div>
+        <div class="rounded-chip" style="--radius:9999px"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">lg</strong>
+          <span style="color:var(--text-muted);">0.5rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.5rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">md</strong>
+          <span style="color:var(--text-muted);">0.375rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.375rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">sm</strong>
+          <span style="color:var(--text-muted);">0.125rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.125rem"></div>
+      </div><div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">xl</strong>
+          <span style="color:var(--text-muted);">0.75rem</span>
+        </div>
+        <div class="rounded-chip" style="--radius:0.75rem"></div>
+      </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- COMPONENTS TAB -->
+      <div id="tab-components" class="tab-content">
+        <div class="masonry">
+          <article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">badge-celestial</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#e7d1ff</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>4px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>9999px</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#6b5586</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Space Grotesk 14px/20px (500)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-primary</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#fff6df</span>
+      </div><div class="component-prop">
+        <strong>height</strong>
+        <span>48px</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>12px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>0.5rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#3a3000</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Space Grotesk 14px/20px (500)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-primary-hover</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#ffe16d</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-secondary</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>transparent</span>
+      </div><div class="component-prop">
+        <strong>height</strong>
+        <span>48px</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>12px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>0.5rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#bdf4ff</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Space Grotesk 14px/20px (500)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">button-secondary-hover</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>rgba(0, 227, 253, 0.1)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">card-glass-interactive-hover</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>rgba(56, 57, 63, 0.4)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">card-glass-level-2</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>rgba(52, 52, 58, 0.2)</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>24px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>0.75rem</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">hero-headline</h3>
+      <div>
+      <div class="component-prop">
+        <strong>textColor</strong>
+        <span>#fff6df</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Space Grotesk 72px/80px (700)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">input-field</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#0d0e13</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>12px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>0.5rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#e3e1e9</span>
+      </div><div class="component-prop">
+        <strong>typography</strong>
+        <span>Inter 16px/24px (400)</span>
+      </div>
+      </div>
+    </article><article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">list-item-hover</h3>
+      <div>
+      <div class="component-prop">
+        <strong>backgroundColor</strong>
+        <span>#292a2f</span>
+      </div><div class="component-prop">
+        <strong>padding</strong>
+        <span>8px</span>
+      </div><div class="component-prop">
+        <strong>rounded</strong>
+        <span>0.375rem</span>
+      </div><div class="component-prop">
+        <strong>textColor</strong>
+        <span>#fff6df</span>
+      </div>
+      </div>
+    </article>
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+  <script>
+    function showTab(event, tabId) {
+      document.querySelectorAll('.tab-content').forEach(el => el.classList.remove('active'));
+      document.querySelectorAll('.tab-btn').forEach(el => el.classList.remove('active'));
+      
+      document.getElementById(tabId).classList.add('active');
+      event.currentTarget.classList.add('active');
+    }
+  </script>
+</body>
+</html>

--- a/packages/cli/src/commands/show.test.ts
+++ b/packages/cli/src/commands/show.test.ts
@@ -1,0 +1,124 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import showCommand from './show.js';
+
+const VALID_DESIGN = `---
+name: Token Board Demo
+colors:
+  primary: "#0d631b"
+  secondary: "#5d4037"
+typography:
+  display-lg:
+    fontFamily: Noto Serif
+    fontSize: 56px
+    fontWeight: 600
+    lineHeight: 64px
+spacing:
+  md: 16px
+rounded:
+  lg: 24px
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "#ffffff"
+---
+
+## Overview
+
+Demo content.
+`;
+
+describe('show command', () => {
+  let logSpy: any;
+  let errorSpy: any;
+  let tempRoot: string;
+
+  beforeEach(() => {
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    tempRoot = mkdtempSync(join(tmpdir(), 'design-md-show-test-'));
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    rmSync(tempRoot, { recursive: true, force: true });
+    process.exitCode = undefined;
+  });
+
+  it('generates an HTML preview in a temp file when open is false', async () => {
+    const inputPath = join(tempRoot, 'DESIGN.md');
+    writeFileSync(inputPath, VALID_DESIGN, 'utf-8');
+
+    await showCommand.run!({
+      args: {
+        file: inputPath,
+        open: 'false',
+        format: 'json',
+      },
+    } as any);
+
+    expect(logSpy.mock.calls.length).toBe(1);
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+
+    expect(output.opened).toBe(false);
+    expect(output.filePath).toBeDefined();
+    expect(existsSync(output.filePath)).toBe(true);
+
+    const html = readFileSync(output.filePath, 'utf-8');
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('Token Board Demo');
+    expect(html).toContain('color-card');
+  });
+
+  it('writes to a custom output path when --output is provided', async () => {
+    const inputPath = join(tempRoot, 'DESIGN.md');
+    const outputPath = join(tempRoot, 'preview', 'design-preview.html');
+    writeFileSync(inputPath, VALID_DESIGN, 'utf-8');
+
+    await showCommand.run!({
+      args: {
+        file: inputPath,
+        output: outputPath,
+        open: 'false',
+        format: 'json',
+      },
+    } as any);
+
+    expect(logSpy.mock.calls.length).toBe(1);
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output.filePath).toBe(outputPath);
+    expect(existsSync(outputPath)).toBe(true);
+  });
+
+  it('returns an error for stdin input in v1', async () => {
+    await showCommand.run!({
+      args: {
+        file: '-',
+        open: 'false',
+      },
+    } as any);
+
+    expect(errorSpy.mock.calls.length).toBe(1);
+    const errorOutput = JSON.parse(errorSpy.mock.calls[0][0]);
+    expect(errorOutput.error).toBe('SHOW_STDIN_UNSUPPORTED');
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/show.ts
+++ b/packages/cli/src/commands/show.ts
@@ -1,0 +1,188 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { spawn } from 'node:child_process';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { defineCommand } from 'citty';
+import { lint } from '../linter/index.js';
+import { ShowHandler } from '../linter/show/handler.js';
+import { formatOutput, readInput } from '../utils.js';
+
+export default defineCommand({
+  meta: {
+    name: 'show',
+    description: 'Generate an offline HTML token-board preview from DESIGN.md.',
+  },
+  args: {
+    file: {
+      type: 'positional',
+      description: 'Path to DESIGN.md (stdin is not supported in show v1)',
+      required: true,
+    },
+    output: {
+      type: 'string',
+      description: 'Optional output path for the generated HTML file',
+    },
+    open: {
+      type: 'string',
+      description: 'Open generated HTML in browser (true/false)',
+      default: 'true',
+    },
+    format: {
+      type: 'string',
+      description: 'Output format: json or markdown',
+      default: 'json',
+    },
+  },
+  async run({ args }) {
+    if (args.file === '-') {
+      console.error(JSON.stringify({
+        error: 'SHOW_STDIN_UNSUPPORTED',
+        message: 'The show command currently supports file paths only.',
+      }));
+      process.exitCode = 1;
+      return;
+    }
+
+    const shouldOpen = parseOpenArg(args.open);
+    const sourcePath = resolve(args.file);
+    const content = await readInput(args.file);
+
+    let report;
+    try {
+      report = lint(content);
+    } catch (error) {
+      console.error(JSON.stringify({
+        error: 'SHOW_PARSE_FAILED',
+        message: error instanceof Error ? error.message : String(error),
+      }));
+      process.exitCode = 1;
+      return;
+    }
+
+    const handler = new ShowHandler();
+    const result = handler.execute({
+      designSystem: report.designSystem,
+      findings: report.findings,
+      summary: report.summary,
+      sourcePath,
+    });
+
+    if (!result.success) {
+      console.error(JSON.stringify({ error: result.error.code, message: result.error.message }));
+      process.exitCode = 1;
+      return;
+    }
+
+    const filePath = await writePreviewFile(result.data.html, args.output);
+
+    let opened = false;
+    let openError: string | undefined;
+
+    if (shouldOpen) {
+      const openResult = await openInBrowser(filePath);
+      opened = openResult.opened;
+      openError = openResult.error;
+    }
+
+    const output = {
+      filePath,
+      opened,
+      openError,
+      summary: report.summary,
+      counts: result.data.model.counts,
+    };
+
+    console.log(formatOutput(output, args));
+    process.exitCode = report.summary.errors > 0 ? 1 : 0;
+  },
+});
+
+function parseOpenArg(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return true;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (['false', '0', 'off', 'no'].includes(normalized)) {
+    return false;
+  }
+  if (['true', '1', 'on', 'yes'].includes(normalized)) {
+    return true;
+  }
+
+  return true;
+}
+
+async function writePreviewFile(html: string, outputPath?: string): Promise<string> {
+  if (outputPath) {
+    const absolute = resolve(outputPath);
+    await mkdir(dirname(absolute), { recursive: true });
+    await writeFile(absolute, html, 'utf-8');
+    return absolute;
+  }
+
+  const tempDirectory = await mkdtemp(join(tmpdir(), 'design-md-show-'));
+  const tempFile = join(tempDirectory, 'design-preview.html');
+  await writeFile(tempFile, html, 'utf-8');
+  return tempFile;
+}
+
+async function openInBrowser(filePath: string): Promise<{ opened: boolean; error?: string }> {
+  const targetPath = resolve(filePath);
+
+  const command = process.platform === 'win32'
+    ? { command: 'cmd', args: ['/c', 'start', '', targetPath] }
+    : process.platform === 'darwin'
+      ? { command: 'open', args: [targetPath] }
+      : { command: 'xdg-open', args: [targetPath] };
+
+  return new Promise((resolveOpen) => {
+    let settled = false;
+
+    try {
+      const child = spawn(command.command, command.args, {
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+
+      child.once('error', (error) => {
+        settled = true;
+        resolveOpen({
+          opened: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+
+      child.unref();
+      setImmediate(() => {
+        if (!settled) {
+          resolveOpen({ opened: true });
+        }
+      });
+    } catch (error) {
+      resolveOpen({
+        opened: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import lintCommand from './commands/lint.js';
 import diffCommand from './commands/diff.js';
 import exportCommand from './commands/export.js';
 import specCommand from './commands/spec.js';
+import showCommand from './commands/show.js';
 
 const main = defineCommand({
   meta: {
@@ -31,6 +32,7 @@ const main = defineCommand({
     diff: diffCommand,
     export: exportCommand,
     spec: specCommand,
+    show: showCommand,
   },
 });
 

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -57,6 +57,24 @@ describe('ModelHandler', () => {
       const accent = result.designSystem.colors.get('accent');
       expect(accent?.hex).toBe('#aabbcc');
     });
+
+    it('normalizes #RGBA shorthand to #RRGGBBAA and extracts alpha', () => {
+      const result = handler.execute(makeParsed({
+        colors: { transparent: '#abc0' },
+      }));
+      const transparent = result.designSystem.colors.get('transparent');
+      expect(transparent?.hex).toBe('#aabbcc00');
+      expect(transparent?.a).toBe(0);
+    });
+
+    it('accepts 8-digit hex colors and extracts alpha', () => {
+      const result = handler.execute(makeParsed({
+        colors: { semitransparent: '#FFFFFFA6' },
+      }));
+      const semitransparent = result.designSystem.colors.get('semitransparent');
+      expect(semitransparent?.hex).toBe('#ffffffa6');
+      expect(semitransparent?.a).toBeCloseTo(166 / 255, 5);
+    });
   });
 
   // ── Cycle 10: Resolve single-level token reference ────────────────

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -203,12 +203,16 @@ export class ModelHandler implements ModelSpec {
 /**
  * Parse a hex color string into a ResolvedColor with RGB + WCAG luminance.
  */
-function parseColor(raw: string): ResolvedColor {
+export function parseColor(raw: string): ResolvedColor {
   let hex = raw;
 
   // Normalize #RGB to #RRGGBB
   if (hex.length === 4) {
     hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  }
+  // Normalize #RGBA to #RRGGBBAA
+  if (hex.length === 5) {
+    hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}${hex[4]}${hex[4]}`;
   }
 
   hex = hex.toLowerCase();
@@ -217,9 +221,14 @@ function parseColor(raw: string): ResolvedColor {
   const g = parseInt(hex.slice(3, 5), 16);
   const b = parseInt(hex.slice(5, 7), 16);
 
+  let a: number | undefined;
+  if (hex.length === 9) {
+    a = parseInt(hex.slice(7, 9), 16) / 255;
+  }
+
   const luminance = computeLuminance(r, g, b);
 
-  return { type: 'color', hex, r, g, b, luminance };
+  return { type: 'color', hex, r, g, b, a, luminance };
 }
 
 /**

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -36,6 +36,8 @@ export interface ResolvedColor {
   r: number;
   g: number;
   b: number;
+  /** Alpha channel from 0 to 1. Optional, defaults to 1 if not present. */
+  a?: number;
   /** WCAG relative luminance */
   luminance: number;
 }
@@ -146,10 +148,10 @@ export function parseDimensionParts(raw: string): { value: number; unit: string 
 }
 
 /**
- * Validate a hex color string. Accepts #RGB and #RRGGBB.
+ * Validate a hex color string. Accepts #RGB, #RGBA, #RRGGBB, and #RRGGBBAA.
  */
 export function isValidColor(raw: string): boolean {
-  return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(raw);
+  return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(raw);
 }
 
 /**

--- a/packages/cli/src/linter/show/handler.test.ts
+++ b/packages/cli/src/linter/show/handler.test.ts
@@ -1,0 +1,83 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'bun:test';
+import { lint } from '../index.js';
+import { ShowHandler } from './handler.js';
+
+describe('ShowHandler', () => {
+  it('renders a deterministic token-board HTML preview', () => {
+    const report = lint(`---
+name: Garden Ledger
+colors:
+  primary: "#0d631b"
+  tertiary: "#b2ad7d"
+typography:
+  headline-lg:
+    fontFamily: Noto Serif
+    fontSize: 32px
+    fontWeight: 600
+    lineHeight: 40px
+spacing:
+  md: 16px
+rounded:
+  lg: 24px
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "#ffffff"
+---
+
+## Overview
+
+Example.
+`);
+
+    const handler = new ShowHandler();
+    const result = handler.execute({
+      designSystem: report.designSystem,
+      findings: report.findings,
+      summary: report.summary,
+      sourcePath: '/tmp/DESIGN.md',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data.model.counts.colors).toBe(2);
+    expect(result.data.model.counts.typography).toBe(1);
+    expect(result.data.html).toContain('Garden Ledger');
+    expect(result.data.html).toContain('color-card');
+    expect(result.data.html).toContain('type-header');
+  });
+
+  it('keeps rendering when lint returns recoverable warnings', () => {
+    const report = lint('# No frontmatter');
+
+    const handler = new ShowHandler();
+    const result = handler.execute({
+      designSystem: report.designSystem,
+      findings: report.findings,
+      summary: report.summary,
+      sourcePath: '/tmp/DESIGN.md',
+    });
+
+    expect(report.summary.warnings).toBeGreaterThan(0);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data.model.counts.colors).toBe(0);
+    expect(result.data.html).toContain('Diagnostics: 0 errors');
+  });
+});

--- a/packages/cli/src/linter/show/handler.ts
+++ b/packages/cli/src/linter/show/handler.ts
@@ -1,0 +1,211 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { basename } from 'node:path';
+import type {
+  ResolvedColor,
+  ResolvedDimension,
+  ResolvedTypography,
+  ResolvedValue,
+} from '../model/spec.js';
+import { renderShowTemplate } from './template.js';
+import type {
+  ShowColorToken,
+  ShowComponentToken,
+  ShowDimensionToken,
+  ShowInput,
+  ShowModel,
+  ShowResult,
+  ShowSpec,
+  ShowTypographyToken,
+} from './spec.js';
+
+const SHADE_STOPS = [-0.75, -0.55, -0.35, -0.15, 0, 0.2, 0.4, 0.6] as const;
+
+/**
+ * Converts a lint report into a deterministic token-board preview model and HTML.
+ */
+export class ShowHandler implements ShowSpec {
+  execute(input: ShowInput): ShowResult {
+    try {
+      const model = this.buildModel(input);
+      const html = renderShowTemplate(model);
+      return {
+        success: true,
+        data: {
+          model,
+          html,
+        },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          code: 'SHOW_RENDER_FAILED',
+          message: error instanceof Error ? error.message : String(error),
+        },
+      };
+    }
+  }
+
+  private buildModel(input: ShowInput): ShowModel {
+    const colors = this.mapColors(input.designSystem.colors);
+    const typography = this.mapTypography(input.designSystem.typography);
+    const spacing = this.mapDimensions(input.designSystem.spacing);
+    const rounded = this.mapDimensions(input.designSystem.rounded);
+    const components = this.mapComponents(input.designSystem.components);
+
+    return {
+      title: input.designSystem.name || 'DESIGN.md Token Board',
+      sourceFile: basename(input.sourcePath),
+      generatedAtIso: new Date().toISOString(),
+      summary: input.summary,
+      diagnostics: input.findings,
+      counts: {
+        colors: colors.length,
+        typography: typography.length,
+        spacing: spacing.length,
+        rounded: rounded.length,
+        components: components.length,
+      },
+      colors,
+      typography,
+      spacing,
+      rounded,
+      components,
+    };
+  }
+
+  private mapColors(colors: Map<string, ResolvedColor>): ShowColorToken[] {
+    return Array.from(colors.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([name, color]) => ({
+        name,
+        hex: color.hex,
+        rgb: `${color.r}, ${color.g}, ${color.b}`,
+        luminance: color.luminance.toFixed(4),
+        shades: this.buildShades(color),
+      }));
+  }
+
+  private mapTypography(typography: Map<string, ResolvedTypography>): ShowTypographyToken[] {
+    return Array.from(typography.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([name, token]) => ({
+        name,
+        fontFamily: token.fontFamily || 'serif',
+        fontSize: this.dimensionToString(token.fontSize),
+        fontWeight: token.fontWeight !== undefined ? String(token.fontWeight) : '400',
+        lineHeight: this.dimensionToString(token.lineHeight),
+        letterSpacing: this.dimensionToString(token.letterSpacing),
+        fontFeature: token.fontFeature || 'none',
+        fontVariation: token.fontVariation || 'none',
+        sample: 'Aa',
+      }));
+  }
+
+  private mapDimensions(dimensions: Map<string, ResolvedDimension>): ShowDimensionToken[] {
+    return Array.from(dimensions.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([name, dimension]) => ({
+        name,
+        value: this.dimensionToString(dimension),
+        approxPx: this.toApproxPx(dimension),
+      }));
+  }
+
+  private mapComponents(
+    components: Map<string, { properties: Map<string, ResolvedValue> }>,
+  ): ShowComponentToken[] {
+    return Array.from(components.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([name, component]) => ({
+        name,
+        properties: Array.from(component.properties.entries())
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([propName, value]) => ({
+            name: propName,
+            value: this.valueToString(value),
+          })),
+      }));
+  }
+
+  private valueToString(value: ResolvedValue): string {
+    if (typeof value === 'string') {
+      return value;
+    }
+
+    if (value.type === 'color') {
+      return value.hex;
+    }
+
+    if (value.type === 'dimension') {
+      return this.dimensionToString(value);
+    }
+
+    if (value.type === 'typography') {
+      const family = value.fontFamily || 'inherit';
+      const size = this.dimensionToString(value.fontSize);
+      const lineHeight = this.dimensionToString(value.lineHeight);
+      const weight = value.fontWeight !== undefined ? String(value.fontWeight) : '400';
+      return `${family} ${size}/${lineHeight} (${weight})`;
+    }
+
+    return String(value);
+  }
+
+  private dimensionToString(value: ResolvedDimension | undefined): string {
+    if (!value) {
+      return 'n/a';
+    }
+
+    const numeric = Number.isInteger(value.value) ? String(value.value) : String(value.value);
+    return `${numeric}${value.unit}`;
+  }
+
+  private toApproxPx(value: ResolvedDimension): number {
+    if (value.unit === 'px') {
+      return value.value;
+    }
+
+    if (value.unit === 'rem' || value.unit === 'em') {
+      return value.value * 16;
+    }
+
+    return value.value;
+  }
+
+  private buildShades(color: ResolvedColor): string[] {
+    return SHADE_STOPS.map((stop) => this.shiftHex(color, stop));
+  }
+
+  private shiftHex(color: ResolvedColor, amount: number): string {
+    const shift = (channel: number) => {
+      if (amount >= 0) {
+        return Math.round(channel + (255 - channel) * amount);
+      }
+      return Math.round(channel * (1 + amount));
+    };
+
+    const r = this.channelToHex(shift(color.r));
+    const g = this.channelToHex(shift(color.g));
+    const b = this.channelToHex(shift(color.b));
+    return `#${r}${g}${b}`;
+  }
+
+  private channelToHex(channel: number): string {
+    const clamped = Math.max(0, Math.min(255, channel));
+    return clamped.toString(16).padStart(2, '0');
+  }
+}

--- a/packages/cli/src/linter/show/spec.ts
+++ b/packages/cli/src/linter/show/spec.ts
@@ -1,0 +1,104 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../model/spec.js';
+import type { Finding } from '../linter/spec.js';
+
+export interface ShowSummary {
+  errors: number;
+  warnings: number;
+  infos: number;
+}
+
+export interface ShowInput {
+  designSystem: DesignSystemState;
+  findings: Finding[];
+  summary: ShowSummary;
+  sourcePath: string;
+}
+
+export interface ShowColorToken {
+  name: string;
+  hex: string;
+  rgb: string;
+  luminance: string;
+  shades: string[];
+}
+
+export interface ShowTypographyToken {
+  name: string;
+  fontFamily: string;
+  fontSize: string;
+  fontWeight: string;
+  lineHeight: string;
+  letterSpacing: string;
+  fontFeature: string;
+  fontVariation: string;
+  sample: string;
+}
+
+export interface ShowDimensionToken {
+  name: string;
+  value: string;
+  approxPx: number;
+}
+
+export interface ShowComponentToken {
+  name: string;
+  properties: Array<{ name: string; value: string }>;
+}
+
+export interface ShowCounts {
+  colors: number;
+  typography: number;
+  spacing: number;
+  rounded: number;
+  components: number;
+}
+
+export interface ShowModel {
+  title: string;
+  sourceFile: string;
+  generatedAtIso: string;
+  summary: ShowSummary;
+  diagnostics: Finding[];
+  counts: ShowCounts;
+  colors: ShowColorToken[];
+  typography: ShowTypographyToken[];
+  spacing: ShowDimensionToken[];
+  rounded: ShowDimensionToken[];
+  components: ShowComponentToken[];
+}
+
+export interface ShowResultData {
+  model: ShowModel;
+  html: string;
+}
+
+export type ShowResult =
+  | {
+      success: true;
+      data: ShowResultData;
+    }
+  | {
+      success: false;
+      error: {
+        code: string;
+        message: string;
+      };
+    };
+
+export interface ShowSpec {
+  execute(input: ShowInput): ShowResult;
+}

--- a/packages/cli/src/linter/show/template.ts
+++ b/packages/cli/src/linter/show/template.ts
@@ -1,0 +1,525 @@
+import type {
+  ShowColorToken,
+  ShowComponentToken,
+  ShowDimensionToken,
+  ShowModel,
+  ShowTypographyToken,
+} from './spec.js';
+
+export function renderShowTemplate(model: ShowModel): string {
+  const diagnosticsCount = model.summary.errors + model.summary.warnings;
+
+  // Overview limited items
+  const overviewColors = model.colors.slice(0, 4);
+  const overviewTypography = model.typography.slice(0, 2);
+  const overviewSpacing = model.spacing.slice(0, 6);
+  const overviewRounded = model.rounded.slice(0, 6);
+  
+  const compLimit = 4;
+  const overviewComponents = model.components.slice(0, compLimit);
+  const compMid = Math.ceil(overviewComponents.length / 2);
+  const col3Components = overviewComponents.slice(0, compMid);
+  const col4Components = overviewComponents.slice(compMid);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(model.title)} - DESIGN.md Show</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;700&family=Noto+Serif:wght@400;700&display=swap');
+
+    :root {
+      --bg-dark: #242424;
+      --board-bg: #e2e2db;
+      --board-border: #7951ff;
+      --card-bg: #f5f5f0;
+      --text-main: #333333;
+      --text-muted: #888888;
+      --radius-xl: 1.5rem;
+      --radius-lg: 1rem;
+      --radius-md: 0.75rem;
+      --radius-sm: 0.5rem;
+      --radius-pill: 9999px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "Manrope", sans-serif;
+      color: var(--text-main);
+      background-color: var(--bg-dark);
+      background-image: radial-gradient(#3a3a3a 1px, transparent 0);
+      background-size: 20px 20px;
+      padding: 2rem 4rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .page-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      color: white;
+      padding: 0 1rem;
+    }
+
+    .page-title {
+      font-weight: 700;
+      font-size: 1.25rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    
+    .page-title svg {
+      width: 24px;
+      height: 24px;
+      fill: currentColor;
+    }
+
+    .page-actions {
+      display: flex;
+      gap: 0.5rem;
+      color: #999;
+    }
+
+    .page-actions svg {
+      width: 24px;
+      height: 24px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 2;
+    }
+
+    .board-container {
+      border: 4px solid var(--board-border);
+      border-radius: var(--radius-xl);
+      background: var(--board-bg);
+      padding: 1.5rem;
+      box-shadow: 0 24px 48px rgba(0,0,0,0.2);
+    }
+
+    .tabs {
+      display: flex;
+      gap: 1.5rem;
+      margin-bottom: 1.5rem;
+      border-bottom: 2px solid rgba(0,0,0,0.05);
+      padding-bottom: 0.5rem;
+    }
+
+    .tab-btn {
+      background: none;
+      border: none;
+      color: var(--text-muted);
+      font-family: "Manrope", sans-serif;
+      font-weight: 700;
+      font-size: 1rem;
+      cursor: pointer;
+      padding: 0.5rem 0.25rem;
+      border-bottom: 3px solid transparent;
+      margin-bottom: -0.5rem;
+      transition: color 0.2s, border-color 0.2s;
+    }
+
+    .tab-btn:hover {
+      color: var(--text-main);
+    }
+
+    .tab-btn.active {
+      color: var(--text-main);
+      border-bottom-color: var(--board-border);
+    }
+
+    .tab-content {
+      display: none;
+      animation: fadeIn 0.3s ease;
+    }
+
+    .tab-content.active {
+      display: block;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(5px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    /* Column layouts for Overview */
+    .grid-4 {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 1.5rem;
+      align-items: start;
+    }
+
+    .column {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    /* Masonry layout for inner tabs */
+    .masonry {
+      column-count: 4;
+      column-gap: 1.5rem;
+    }
+    .masonry > * {
+      break-inside: avoid;
+      margin-bottom: 1.5rem;
+    }
+    
+    .grid-auto {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 1.5rem;
+      align-items: start;
+    }
+
+    /* Cards */
+    .card {
+      background: var(--card-bg);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+      padding: 1.25rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    /* Color Card */
+    .color-card {
+      padding: 0;
+      gap: 0;
+    }
+    .color-main {
+      padding: 1.25rem;
+      display: flex;
+      justify-content: space-between;
+      font-weight: 700;
+      font-size: 0.9rem;
+      min-height: 120px;
+    }
+    .color-shades {
+      display: flex;
+      height: 36px;
+    }
+    .color-shades i {
+      flex: 1;
+      background: var(--shade);
+    }
+
+    /* Typography Card */
+    .type-header {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin-bottom: 2.5rem;
+    }
+    .type-sample {
+      margin: 0;
+      text-align: center;
+      font-size: 6.5rem;
+      line-height: 1;
+      color: #333;
+      padding-bottom: 1.5rem;
+    }
+
+    /* Dimension Rows */
+    .dim-row {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 0.5rem;
+      font-size: 0.85rem;
+      margin-bottom: 0.5rem;
+      align-items: center;
+    }
+    .dim-bar {
+      grid-column: 1 / -1;
+      height: 6px;
+      border-radius: var(--radius-pill);
+      background: rgba(0,0,0,0.05);
+      margin-bottom: 1rem;
+    }
+    .dim-bar i {
+      display: block;
+      height: 100%;
+      border-radius: var(--radius-pill);
+      background: #5d665b;
+      width: var(--width);
+    }
+    .rounded-chip {
+      height: 32px;
+      background: rgba(0,0,0,0.1);
+      border-radius: var(--radius);
+      margin-top: 0.25rem;
+    }
+
+    /* Components */
+    .component-prop {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.85rem;
+      padding: 0.35rem 0;
+      border-bottom: 1px solid rgba(0,0,0,0.05);
+    }
+    .component-prop:last-child {
+      border-bottom: none;
+    }
+    .component-prop strong {
+      color: var(--text-muted);
+      font-weight: 400;
+    }
+
+    .diagnostics {
+      margin-bottom: 1rem;
+      border-radius: var(--radius-md);
+      padding: 1rem;
+      background: ${diagnosticsCount > 0 ? '#ffebee' : '#e8f5e9'};
+      color: ${diagnosticsCount > 0 ? '#c62828' : '#2e7d32'};
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 1200px) {
+      .grid { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (max-width: 768px) {
+      .grid { grid-template-columns: 1fr; }
+      body { padding: 1rem; }
+    }
+  </style>
+</head>
+<body>
+  <header class="page-header">
+    <div class="page-title">
+      <svg viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/></svg>
+      ${escapeHtml(model.title)}
+    </div>
+    <div class="page-actions">
+      <svg viewBox="0 0 24 24"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon></svg>
+      <svg viewBox="0 0 24 24"><path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"></path></svg>
+      <svg viewBox="0 0 24 24"><path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h3a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2h-3"></path></svg>
+    </div>
+  </header>
+
+  <div class="board-container">
+    ${diagnosticsCount > 0 ? renderDiagnostics(model) : ''}
+    
+    <nav class="tabs">
+      <button class="tab-btn active" onclick="showTab(event, 'tab-overview')">Overview</button>
+      ${model.colors.length > 0 ? `<button class="tab-btn" onclick="showTab(event, 'tab-colors')">Colors (${model.colors.length})</button>` : ''}
+      ${model.typography.length > 0 ? `<button class="tab-btn" onclick="showTab(event, 'tab-typography')">Typography (${model.typography.length})</button>` : ''}
+      ${model.spacing.length > 0 ? `<button class="tab-btn" onclick="showTab(event, 'tab-layout')">Layout (${model.spacing.length})</button>` : ''}
+      ${model.rounded.length > 0 ? `<button class="tab-btn" onclick="showTab(event, 'tab-shapes')">Shapes (${model.rounded.length})</button>` : ''}
+      ${model.components.length > 0 ? `<button class="tab-btn" onclick="showTab(event, 'tab-components')">Components (${model.components.length})</button>` : ''}
+    </nav>
+
+    <main class="board">
+      
+      <!-- OVERVIEW TAB -->
+      <div id="tab-overview" class="tab-content active">
+        <div class="grid-4">
+          <div class="column">
+            ${renderColorCards(overviewColors)}
+          </div>
+          <div class="column">
+            ${renderTypographyCards(overviewTypography)}
+          </div>
+          <div class="column">
+            <div class="card">
+              <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">Spacing</h3>
+              ${renderDimensionRows(overviewSpacing, 'spacing')}
+            </div>
+            ${renderComponentCards(col3Components)}
+          </div>
+          <div class="column">
+            <div class="card">
+              <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">Rounded</h3>
+              ${renderDimensionRows(overviewRounded, 'rounded')}
+            </div>
+            ${renderComponentCards(col4Components)}
+          </div>
+        </div>
+      </div>
+
+      <!-- COLORS TAB -->
+      <div id="tab-colors" class="tab-content">
+        <div class="grid-auto">
+          ${renderColorCards(model.colors)}
+        </div>
+      </div>
+
+      <!-- TYPOGRAPHY TAB -->
+      <div id="tab-typography" class="tab-content">
+        <div class="grid-auto">
+          ${renderTypographyCards(model.typography)}
+        </div>
+      </div>
+
+      <!-- LAYOUT (SPACING) TAB -->
+      <div id="tab-layout" class="tab-content">
+        <div class="masonry">
+          <div class="card">
+            <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">All Spacing Tokens</h3>
+            ${renderDimensionRows(model.spacing, 'spacing')}
+          </div>
+        </div>
+      </div>
+
+      <!-- SHAPES (ROUNDED) TAB -->
+      <div id="tab-shapes" class="tab-content">
+        <div class="masonry">
+          <div class="card">
+            <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-muted);font-weight:400;">All Rounded Tokens</h3>
+            ${renderDimensionRows(model.rounded, 'rounded')}
+          </div>
+        </div>
+      </div>
+
+      <!-- COMPONENTS TAB -->
+      <div id="tab-components" class="tab-content">
+        <div class="masonry">
+          ${renderComponentCards(model.components)}
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+  <script>
+    function showTab(event, tabId) {
+      document.querySelectorAll('.tab-content').forEach(el => el.classList.remove('active'));
+      document.querySelectorAll('.tab-btn').forEach(el => el.classList.remove('active'));
+      
+      document.getElementById(tabId).classList.add('active');
+      event.currentTarget.classList.add('active');
+    }
+  </script>
+</body>
+</html>`;
+}
+
+function renderDiagnostics(model: ShowModel): string {
+  const diagnosticsCount = model.summary.errors + model.summary.warnings;
+  const findings = model.diagnostics
+    .filter((finding) => finding.severity === 'error' || finding.severity === 'warning')
+    .slice(0, 6);
+
+  return `<div class="diagnostics">
+    <p style="margin:0 0 0.5rem;font-weight:bold;">Diagnostics: ${model.summary.errors} errors, ${model.summary.warnings} warnings</p>
+    ${findings.length > 0 ? `<ul style="margin:0;padding-left:1.5rem;">${findings
+      .map((finding) => `<li>${escapeHtml(`${finding.path ? `[${finding.path}] ` : ''}${finding.message}`)}</li>`)
+      .join('')}</ul>` : ''}
+  </div>`;
+}
+
+function renderColorCards(colors: ShowColorToken[]): string {
+  if (colors.length === 0) return '<div class="card empty">No color tokens.</div>';
+
+  return colors
+    .map((token) => {
+      const isDark = Number(token.luminance) < 0.4;
+      const textColor = isDark ? '#ffffff' : '#000000';
+      return `<article class="card color-card">
+      <div class="color-main" style="background-color: ${escapeAttr(token.hex)}; color: ${textColor};">
+        <span>${escapeHtml(token.name)}</span>
+        <span>${escapeHtml(token.hex.toUpperCase())}</span>
+      </div>
+      <div class="color-shades">
+        ${token.shades.map((shade) => `<i style="--shade:${escapeAttr(shade)}"></i>`).join('')}
+      </div>
+    </article>`
+    })
+    .join('');
+}
+
+function renderTypographyCards(typography: ShowTypographyToken[]): string {
+  if (typography.length === 0) return '<div class="card empty">No typography tokens.</div>';
+
+  return typography
+    .map((token) => {
+      const style = [
+        `font-family:${safeCssValue(token.fontFamily)}`,
+        `font-size: 6.5rem`,
+        `font-weight:${safeCssValue(token.fontWeight)}`,
+        token.letterSpacing !== 'n/a' ? `letter-spacing:${safeCssValue(token.letterSpacing)}` : '',
+      ]
+        .filter(Boolean)
+        .join(';');
+
+      return `<article class="card">
+        <div class="type-header">
+          <span>${escapeHtml(token.name)}</span>
+          <span>${escapeHtml(token.fontFamily)}</span>
+        </div>
+        <p class="type-sample" style="${escapeAttr(style)}">Aa</p>
+      </article>`;
+    })
+    .join('');
+}
+
+function renderDimensionRows(dimensions: ShowDimensionToken[], mode: 'spacing' | 'rounded'): string {
+  if (dimensions.length === 0) return `<div class="empty">No ${mode} tokens.</div>`;
+
+  return dimensions
+    .map((token) => {
+      const width = clamp(token.approxPx * 2.2, 12, 240);
+      const visual = mode === 'rounded'
+        ? `<div class="rounded-chip" style="--radius:${escapeAttr(token.value)}"></div>`
+        : `<div class="dim-bar"><i style="--width:${escapeAttr(`${width}px`)}"></i></div>`;
+
+      return `<div>
+        <div class="dim-row">
+          <strong style="color:var(--text-main);font-weight:700;">${escapeHtml(token.name)}</strong>
+          <span style="color:var(--text-muted);">${escapeHtml(token.value)}</span>
+        </div>
+        ${visual}
+      </div>`;
+    })
+    .join('');
+}
+
+function renderComponentCards(components: ShowComponentToken[]): string {
+  if (components.length === 0) return '';
+
+  return components
+    .map((component) => `<article class="card">
+      <h3 style="margin:0 0 1rem;font-size:0.9rem;color:var(--text-main);font-weight:400;">${escapeHtml(component.name)}</h3>
+      <div>
+      ${component.properties.map((property) => `<div class="component-prop">
+        <strong>${escapeHtml(property.name)}</strong>
+        <span>${escapeHtml(property.value)}</span>
+      </div>`).join('')}
+      </div>
+    </article>`)
+    .join('');
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeAttr(value: string): string {
+  return escapeHtml(value);
+}
+
+function safeCssValue(value: string): string {
+  return value.replace(/[;{}<>`]/g, '');
+}


### PR DESCRIPTION
This PR adds support for 4 and 8-digit HEX color codes (e.g., #RGBA and #RRGGBBAA) in the design.md CLI linter.

Currently, colors with an alpha channel are rejected by the validator. This fix:
1. Updates the color validation regex to accept 4 and 8 character hex codes.
2. Updates the color parsing logic to normalize these codes and extract the alpha channel.
3. Adds unit tests to verify the fix.