### PR TITLE
supporting transparent hex colors

### DIFF
--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -57,6 +57,24 @@ describe('ModelHandler', () => {
       const accent = result.designSystem.colors.get('accent');
       expect(accent?.hex).toBe('#aabbcc');
     });
+
+    it('normalizes #RGBA shorthand to #RRGGBBAA and extracts alpha', () => {
+      const result = handler.execute(makeParsed({
+        colors: { transparent: '#abc0' },
+      }));
+      const transparent = result.designSystem.colors.get('transparent');
+      expect(transparent?.hex).toBe('#aabbcc00');
+      expect(transparent?.a).toBe(0);
+    });
+
+    it('accepts 8-digit hex colors and extracts alpha', () => {
+      const result = handler.execute(makeParsed({
+        colors: { semitransparent: '#FFFFFFA6' },
+      }));
+      const semitransparent = result.designSystem.colors.get('semitransparent');
+      expect(semitransparent?.hex).toBe('#ffffffa6');
+      expect(semitransparent?.a).toBeCloseTo(166 / 255, 5);
+    });
   });
 
   // ── Cycle 10: Resolve single-level token reference ────────────────

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -203,12 +203,16 @@ export class ModelHandler implements ModelSpec {
 /**
  * Parse a hex color string into a ResolvedColor with RGB + WCAG luminance.
  */
-function parseColor(raw: string): ResolvedColor {
+export function parseColor(raw: string): ResolvedColor {
   let hex = raw;
 
   // Normalize #RGB to #RRGGBB
   if (hex.length === 4) {
     hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  }
+  // Normalize #RGBA to #RRGGBBAA
+  if (hex.length === 5) {
+    hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}${hex[4]}${hex[4]}`;
   }
 
   hex = hex.toLowerCase();
@@ -217,9 +221,14 @@ function parseColor(raw: string): ResolvedColor {
   const g = parseInt(hex.slice(3, 5), 16);
   const b = parseInt(hex.slice(5, 7), 16);
 
+  let a: number | undefined;
+  if (hex.length === 9) {
+    a = parseInt(hex.slice(7, 9), 16) / 255;
+  }
+
   const luminance = computeLuminance(r, g, b);
 
-  return { type: 'color', hex, r, g, b, luminance };
+  return { type: 'color', hex, r, g, b, a, luminance };
 }
 
 /**

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -36,6 +36,8 @@ export interface ResolvedColor {
   r: number;
   g: number;
   b: number;
+  /** Alpha channel from 0 to 1. Optional, defaults to 1 if not present. */
+  a?: number;
   /** WCAG relative luminance */
   luminance: number;
 }
@@ -146,10 +148,10 @@ export function parseDimensionParts(raw: string): { value: number; unit: string 
 }
 
 /**
- * Validate a hex color string. Accepts #RGB and #RRGGBB.
+ * Validate a hex color string. Accepts #RGB, #RGBA, #RRGGBB, and #RRGGBBAA.
  */
 export function isValidColor(raw: string): boolean {
-  return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(raw);
+  return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(raw);
 }
 
 /**


### PR DESCRIPTION
add support for 4-digit and 8-digit HEX color codes (e.g., #RGBA and #RRGGBBAA) in the design.md CLI linter. Previously, the linter only accepted opaque 3 or 6-digit hex codes.

Related Issues
  Fixes #14

Changes
 - Type Definition: Added an optional a (alpha) channel field to the ResolvedColor interface in spec.ts.
 - Validation: Updated the isValidColor regex to accept 4 and 8 character hex strings.
 - Parsing Logic: 
   - Updated parseColor in handler.ts to correctly normalize #RGBA shorthand to #RRGGBBAA.
   - Implemented alpha extraction logic (converting 0-255 hex values to a 0-1 float).
   - Exported parseColor for better testability.
 - Tests: Added new test cases in handler.test.ts to verify normalization and alpha extraction for transparent hex codes.

Verification
 - Ran bun test in packages/cli.
 - Verified that all 72 existing and new tests pass.