### PR TITLE
fix(model): handle numeric component prop values without crashing

### DIFF
--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -356,4 +356,66 @@ describe('ModelHandler', () => {
       }
     });
   });
+
+  // ── Fix #42: numeric component props crash model builder ──────────
+  describe('numeric component property values', () => {
+    it('does not crash when fontWeight is a bare number', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#000000' },
+        components: {
+          'button-primary': {
+            backgroundColor: '{colors.primary}',
+            fontWeight: 600 as unknown as string,
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const btn = result.designSystem.components.get('button-primary');
+      expect(btn).toBeDefined();
+      expect(btn?.properties.get('fontWeight')).toBe(600);
+    });
+
+    it('stores numeric fontWeight value as-is in component properties', () => {
+      const result = handler.execute(makeParsed({
+        components: {
+          'heading': {
+            fontWeight: 700 as unknown as string,
+          },
+        },
+      }));
+      const heading = result.designSystem.components.get('heading');
+      expect(heading?.properties.get('fontWeight')).toBe(700);
+    });
+
+    it('does not crash when borderWidth is a bare number', () => {
+      const result = handler.execute(makeParsed({
+        components: {
+          'card': {
+            borderWidth: 1 as unknown as string,
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const card = result.designSystem.components.get('card');
+      expect(card?.properties.get('borderWidth')).toBe(1);
+    });
+
+    it('handles mixed numeric and string props in same component without crashing', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#ff0000' },
+        spacing: { md: '16px' },
+        components: {
+          'button': {
+            fontWeight: 600 as unknown as string,
+            backgroundColor: '{colors.primary}',
+            padding: '{spacing.md}',
+            borderRadius: '4px',
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const btn = result.designSystem.components.get('button');
+      expect(btn?.properties.get('fontWeight')).toBe(600);
+    });
+  });
 });

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -176,7 +176,13 @@ export class ModelHandler implements ModelSpec {
           const unresolvedRefs: string[] = [];
 
           for (const [propName, rawValue] of Object.entries(props)) {
-            if (isTokenReference(rawValue)) {
+            // Numeric values (e.g. fontWeight: 600, borderWidth: 1) are valid
+            // per spec and must be stored as-is, coercing to string first
+            // would cause isTokenReference / isValidColor to call .match() on
+            // a number and crash with "raw.match is not a function".
+            if (typeof rawValue === 'number') {
+              properties.set(propName, rawValue);
+            } else if (isTokenReference(rawValue)) {
               const refPath = rawValue.slice(1, -1);
               const resolved = resolveReference(symbolTable, refPath, new Set());
               if (resolved !== null) {


### PR DESCRIPTION
Fixes #42

## Problem
The `lint` command crashes with `Unexpected error during model building: 
raw.match is not a function` when a component defines a numeric prop like 
`fontWeight: 600` or `borderWidth: 1`. The spec explicitly states bare 
numbers and quoted strings are equivalent, so this is a spec violation.

## Root Cause
In Phase 3 of `ModelHandler`, all component prop values were passed 
directly to `isTokenReference()` and `isValidColor()`, both of which call 
`.match()` internally. When `rawValue` is a number, `.match` doesn't exist 
— crash.

## Fix
Added a `typeof rawValue === 'number'` guard at the top of the component 
property loop, storing numeric values as-is. This mirrors the pattern 
already used by `parseTypography` for the same property.

## Tests
Added 4 new test cases covering:
- `fontWeight: 600` (exact repro from issue)
- `fontWeight: 700` stored correctly as a number
- `borderWidth: 1` (also mentioned in issue)
- Mixed numeric + string + token ref props in one component