### PR TITLE
feat(spec): add Iconography section and icons.* tokens

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -87,8 +87,9 @@ Every `DESIGN.md` follows the same structure. Sections can be omitted if they're
 4. **Layout** (also: "Layout & Spacing")
 5. **Elevation & Depth** (also: "Elevation")
 6. **Shapes**
-7. **Components**
-8. **Do's and Don'ts**
+7. **Iconography**
+8. **Components**
+9. **Do's and Don'ts**
 
 ### Prose and Tokens
 
@@ -274,6 +275,50 @@ rounded:
   full: 9999px
 ```
 
+## Iconography
+
+This section defines the icon library, style, and size scale used across the product.
+
+Example:
+
+```markdown
+## Iconography
+
+Icons use **Lucide** in its outlined style at a 1.5 stroke weight, echoing
+the calm, linear rhythm of the typography. Icons render on a 24px grid and
+inherit `on-surface` color by default.
+
+- **Small (16px):** Inline with body text or dense tables.
+- **Medium (24px):** Default for buttons, navigation, and form fields.
+- **Large (32px):** Feature tiles and empty states.
+```
+
+### Design Tokens
+
+The `icons` section defines a single token group (not a map) describing the
+icon library in use, its style variant, stroke weight, source grid, render
+sizes, and default color.
+
+```yaml
+icons:
+  library: "Lucide"
+  style: "outlined"
+  strokeWidth: 1.5
+  grid: "24px"
+  size:
+    sm: "16px"
+    md: "24px"
+    lg: "32px"
+  color: "{colors.on-surface}"
+```
+
+* `library` (string) — the icon set in use (e.g., "Lucide", "Heroicons", "Material Symbols"). Agents resolve the string to an import.
+* `style` (enum, optional) — one of: `outlined`, `filled`, `rounded`, `sharp`, `duotone`. Unknown values are preserved with a warning.
+* `strokeWidth` (number, optional) — for stroke-based libraries (Lucide, Tabler, Feather). Font-based libraries (e.g., Material Symbols with its 100–700 weight axis) map this agent-side.
+* `grid` (Dimension, optional) — the source viewBox unit (Radix 15, Phosphor 256, most others 24). Distinct from `size.*`, which is the CSS render size.
+* `size` (map\<string, Dimension>, optional) — named render sizes.
+* `color` (Color or token reference, optional) — default icon color; inherits via CSS `currentColor` unless explicitly set.
+
 ## Components
 
 This section provides style guidance for component atoms within the design system. The following are common component types. Design systems are encouraged to define additional components relevant to their domain.
@@ -341,13 +386,17 @@ The following names are commonly used across design systems. They are not requir
 
 **Rounded:** `none`, `sm`, `md`, `lg`, `xl`, `full`
 
+**Icon-styles:** `outlined`, `filled`, `rounded`, `sharp`, `duotone`
+
+**Icon-sizes:** `sm`, `md`, `lg`
+
 # Consumer Behavior for Unknown Content
 
 When a DESIGN.md consumer encounters content not defined by this spec:
 
 | Scenario | Behavior | Example |
 |---|---|---|
-| Unknown section heading | Preserve; do not error | `## Iconography` |
+| Unknown section heading | Preserve; do not error | `## Illustrations` |
 | Unknown color token name | Accept if value is valid | `surface-container-high: '#ede7dd'` |
 | Unknown typography token name | Accept as valid typography | `telemetry-data` |
 | Unknown spacing value | Accept; store as string if not a valid dimension | `grid-columns: '5'` |

--- a/examples/paws-and-paths/DESIGN.md
+++ b/examples/paws-and-paths/DESIGN.md
@@ -154,6 +154,16 @@ components:
     typography: "{typography.label-sm}"
     rounded: "{rounded.full}"
     padding: "{spacing.xs}"
+icons:
+  library: "Lucide"
+  style: "outlined"
+  strokeWidth: 1.75
+  grid: "24px"
+  size:
+    sm: "16px"
+    md: "20px"
+    lg: "24px"
+  color: "{colors.on-surface}"
 ---
 
 ## Brand & Style
@@ -202,7 +212,14 @@ The shape language is defined by **Rounded** corners, mirroring the soft feature
 - **Buttons:** Main CTA buttons use a `12px` (rounded-lg) radius to feel substantial and clickable.
 - **Cards:** Dog profiles and walker cards use a `1.5rem` (rounded-xl) radius to create a soft, containerized look.
 - **Inputs:** Form fields use a `0.5rem` radius to maintain a professional yet modern appearance.
-- **Icons:** Icons should feature rounded caps and corners to harmonize with the UI's structural elements.
+
+## Iconography
+
+Icons use **Lucide** in its outlined style with a slightly heavier **1.75 stroke weight**, whose rounded line caps mirror the soft corners of the UI and reinforce the friendly, human-centric feel of the brand. Icons render on a 24px grid and inherit `on-surface` color by default so they sit comfortably against any surface tint.
+
+- **Small (16px):** Inline affordances in dense lists and metadata (e.g., status dots next to walker names).
+- **Medium (20px):** Default for buttons, form fields, and navigation — large enough to read at a glance without overpowering the label.
+- **Large (24px):** Feature tiles, empty states, and hero card actions where the icon carries meaning on its own.
 
 ## Components
 

--- a/packages/cli/src/commands/spec.test.ts
+++ b/packages/cli/src/commands/spec.test.ts
@@ -89,6 +89,6 @@ describe('spec command', () => {
     const output = JSON.parse(outputStr);
     expect(output.spec).toBeDefined();
     expect(output.rules).toBeDefined();
-    expect(output.rules.length).toBe(8);
+    expect(output.rules.length).toBe(9);
   });
 });

--- a/packages/cli/src/linter/fixture.test.ts
+++ b/packages/cli/src/linter/fixture.test.ts
@@ -58,4 +58,52 @@ describe('Fixture Test', () => {
     // We expect at least the summary info
     expect(result.summary.infos).toBeGreaterThan(0);
   });
+
+  it('lints ICONS_VALID.md with no errors related to icons', () => {
+    const path = join(import.meta.dir, 'fixtures', 'ICONS_VALID.md');
+    const content = readFileSync(path, 'utf-8');
+
+    const result = lint(content);
+
+    expect(result.designSystem.icons).toBeDefined();
+    expect(result.designSystem.icons!.library).toBe('Lucide');
+    expect(result.designSystem.icons!.style).toBe('outlined');
+    expect(result.designSystem.icons!.size.get('md')?.value).toBe(24);
+
+    const iconErrors = result.findings.filter(
+      (f: { severity: string; path?: string }) =>
+        f.severity === 'error' && f.path?.startsWith('icons')
+    );
+    expect(iconErrors).toEqual([]);
+  });
+
+  it('lints ICONS_INVALID.md surfacing the expected findings', () => {
+    const path = join(import.meta.dir, 'fixtures', 'ICONS_INVALID.md');
+    const content = readFileSync(path, 'utf-8');
+
+    const result = lint(content);
+
+    // Invalid dimension in icons.size.sm → error
+    const sizeError = result.findings.find(
+      (f: { severity: string; path?: string }) =>
+        f.severity === 'error' && f.path === 'icons.size.sm'
+    );
+    expect(sizeError).toBeDefined();
+
+    // Unresolved color reference → error
+    const colorError = result.findings.find(
+      (f: { severity: string; path?: string }) =>
+        f.severity === 'error' && f.path === 'icons.color'
+    );
+    expect(colorError).toBeDefined();
+
+    // Unknown icon style "hexagonal" → warning from the unknown-icon-style rule
+    const styleWarning = result.findings.find(
+      (f: { severity: string; path?: string; message: string }) =>
+        f.severity === 'warning' &&
+        f.path === 'icons.style' &&
+        f.message.includes('hexagonal')
+    );
+    expect(styleWarning).toBeDefined();
+  });
 });

--- a/packages/cli/src/linter/fixtures/ICONS_INVALID.md
+++ b/packages/cli/src/linter/fixtures/ICONS_INVALID.md
@@ -1,0 +1,17 @@
+---
+name: Icons Invalid
+colors:
+  primary: "#1A1C1E"
+icons:
+  library: "Lucide"
+  style: "hexagonal"
+  size:
+    sm: "not-a-dimension"
+  color: "{colors.does-not-exist}"
+---
+
+## Overview
+A fixture that exercises icon-specific lint rules.
+
+## Iconography
+Broken on purpose.

--- a/packages/cli/src/linter/fixtures/ICONS_VALID.md
+++ b/packages/cli/src/linter/fixtures/ICONS_VALID.md
@@ -1,0 +1,34 @@
+---
+name: Icons Valid
+colors:
+  primary: "#1A1C1E"
+  on-surface: "#2a2825"
+typography:
+  body-md:
+    fontFamily: Inter
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.5
+icons:
+  library: "Lucide"
+  style: "outlined"
+  strokeWidth: 1.5
+  grid: 24px
+  size:
+    sm: 16px
+    md: 24px
+    lg: 32px
+  color: "{colors.on-surface}"
+---
+
+## Overview
+A valid fixture demonstrating the iconography block.
+
+## Colors
+Primary and on-surface.
+
+## Typography
+Inter body text.
+
+## Iconography
+Icons use Lucide, outlined, 1.5 stroke.

--- a/packages/cli/src/linter/linter/rules/index.ts
+++ b/packages/cli/src/linter/linter/rules/index.ts
@@ -23,6 +23,7 @@ import { tokenSummaryRule } from './token-summary.js';
 import { missingSectionsRule } from './missing-sections.js';
 import { sectionOrderRule } from './section-order.js';
 import { missingTypographyRule } from './missing-typography.js';
+import { unknownIconStyleRule } from './unknown-icon-style.js';
 
 /** The default set of lint rule descriptors, in order. */
 export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
@@ -34,6 +35,7 @@ export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
   missingSectionsRule,
   missingTypographyRule,
   sectionOrderRule,
+  unknownIconStyleRule,
 ];
 
 /** Converts a RuleDescriptor into a LintRule by injecting severity into findings. */
@@ -58,4 +60,5 @@ export { tokenSummary } from './token-summary.js';
 export { missingSections } from './missing-sections.js';
 export { missingTypography } from './missing-typography.js';
 export { sectionOrder } from './section-order.js';
+export { unknownIconStyle } from './unknown-icon-style.js';
 export type { LintRule } from './types.js';

--- a/packages/cli/src/linter/linter/rules/types.test.ts
+++ b/packages/cli/src/linter/linter/rules/types.test.ts
@@ -40,7 +40,7 @@ describe('LintRule type', () => {
   });
 
   it('has all rules in DEFAULT_RULE_DESCRIPTORS', () => {
-    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(8);
+    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(9);
     DEFAULT_RULE_DESCRIPTORS.forEach((rule: RuleDescriptor) => {
       expect(rule.name).toBeTruthy();
       expect(rule.severity).toBeTruthy();

--- a/packages/cli/src/linter/linter/rules/unknown-icon-style.test.ts
+++ b/packages/cli/src/linter/linter/rules/unknown-icon-style.test.ts
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { unknownIconStyle } from './unknown-icon-style.js';
+import type { DesignSystemState, ResolvedIcons } from '../../model/spec.js';
+
+function makeState(icons?: ResolvedIcons): DesignSystemState {
+  return {
+    colors: new Map(),
+    typography: new Map(),
+    rounded: new Map(),
+    spacing: new Map(),
+    components: new Map(),
+    symbolTable: new Map(),
+    icons,
+  };
+}
+
+describe('unknownIconStyle rule', () => {
+  it('returns no findings when icons block is absent', () => {
+    expect(unknownIconStyle(makeState(undefined))).toEqual([]);
+  });
+
+  it('returns no findings when style is in the canonical enum', () => {
+    const icons: ResolvedIcons = { type: 'icons', style: 'outlined', size: new Map() };
+    expect(unknownIconStyle(makeState(icons))).toEqual([]);
+  });
+
+  it('returns a warning when style is unknown', () => {
+    const icons: ResolvedIcons = { type: 'icons', style: 'hexagonal', size: new Map() };
+    const findings = unknownIconStyle(makeState(icons));
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.path).toBe('icons.style');
+    expect(findings[0]?.message).toMatch(/'hexagonal'/);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/unknown-icon-style.ts
+++ b/packages/cli/src/linter/linter/rules/unknown-icon-style.ts
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+import { ICON_STYLES } from '../../spec-config.js';
+
+/**
+ * Warn when `icons.style` uses a value outside the canonical enum.
+ * Non-normative — unknown values are preserved; this is advisory only.
+ */
+export function unknownIconStyle(state: DesignSystemState): RuleFinding[] {
+  const style = state.icons?.style;
+  if (!style) return [];
+  if (ICON_STYLES.includes(style)) return [];
+  return [{
+    path: 'icons.style',
+    message: `'${style}' is not a canonical icon style. Expected one of: ${ICON_STYLES.join(', ')}.`,
+  }];
+}
+
+export const unknownIconStyleRule: RuleDescriptor = {
+  name: 'unknown-icon-style',
+  severity: 'warning',
+  description: 'Warn when `icons.style` uses a value outside the canonical enum.',
+  run: unknownIconStyle,
+};

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -357,3 +357,59 @@ describe('ModelHandler', () => {
     });
   });
 });
+
+describe('icons resolution', () => {
+  it('populates icons and adds symbol-table entries for sizes, grid, and color', () => {
+    const parsed: ParsedDesignSystem = {
+      colors: { 'on-surface': '#151c27' },
+      icons: {
+        library: 'Lucide',
+        style: 'outlined',
+        strokeWidth: 1.5,
+        grid: '24px',
+        size: { sm: '16px', md: '24px', lg: '32px' },
+        color: '{colors.on-surface}',
+      },
+      sourceMap: new Map(),
+    };
+    const handler = new ModelHandler();
+    const { designSystem, findings } = handler.execute(parsed);
+
+    expect(designSystem.icons).toBeDefined();
+    expect(designSystem.icons!.library).toBe('Lucide');
+    expect(designSystem.icons!.style).toBe('outlined');
+    expect(designSystem.icons!.strokeWidth).toBe(1.5);
+
+    // Symbol table entries for cross-references
+    const sizeMd = designSystem.symbolTable.get('icons.size.md');
+    expect(sizeMd).toBeDefined();
+    expect((sizeMd as any).type).toBe('dimension');
+    expect((sizeMd as any).value).toBe(24);
+
+    const color = designSystem.symbolTable.get('icons.color');
+    expect(color).toBeDefined();
+    expect((color as any).type).toBe('color');
+    expect((color as any).hex).toBe('#151c27');
+
+    // No error findings for a valid icons block
+    expect(findings.filter(f => f.severity === 'error' && f.path?.startsWith('icons'))).toHaveLength(0);
+  });
+
+  it('reports an error for an invalid dimension in icons.size', () => {
+    const parsed: ParsedDesignSystem = {
+      icons: { size: { bad: 'not-a-dim' } },
+      sourceMap: new Map(),
+    };
+    const { findings } = new ModelHandler().execute(parsed);
+    expect(findings.some(f => f.severity === 'error' && f.path === 'icons.size.bad')).toBe(true);
+  });
+
+  it('reports an error for an unresolved color reference', () => {
+    const parsed: ParsedDesignSystem = {
+      icons: { color: '{colors.nonexistent}' },
+      sourceMap: new Map(),
+    };
+    const { findings } = new ModelHandler().execute(parsed);
+    expect(findings.some(f => f.severity === 'error' && f.path === 'icons.color')).toBe(true);
+  });
+});

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -19,6 +19,7 @@ import type {
   ResolvedColor,
   ResolvedDimension,
   ResolvedTypography,
+  ResolvedIcons,
   ResolvedValue,
   ComponentDef,
   Finding,
@@ -198,6 +199,104 @@ export class ModelHandler implements ModelSpec {
         }
       }
 
+      // ── Phase 4: Resolve icons ─────────────────────────────────────
+      let icons: ResolvedIcons | undefined;
+      if (input.icons) {
+        const sizeMap = new Map<string, ResolvedDimension>();
+        if (input.icons.size) {
+          for (const [key, raw] of Object.entries(input.icons.size)) {
+            if (typeof raw === 'string' && isParseableDimension(raw)) {
+              const resolved = parseDimension(raw);
+              if (resolved.unit !== 'px' && resolved.unit !== 'rem' && resolved.unit !== 'em') {
+                findings.push({
+                  severity: 'error',
+                  path: `icons.size.${key}`,
+                  message: `'${raw}' has an invalid unit '${resolved.unit}'. Only px, rem, and em are allowed.`,
+                });
+              }
+              sizeMap.set(key, resolved);
+              symbolTable.set(`icons.size.${key}`, resolved);
+            } else if (typeof raw === 'string' && !isTokenReference(raw)) {
+              findings.push({
+                severity: 'error',
+                path: `icons.size.${key}`,
+                message: `'${raw}' is not a valid dimension.`,
+              });
+            }
+          }
+        }
+
+        let resolvedGrid: ResolvedDimension | undefined;
+        if (typeof input.icons.grid === 'string') {
+          if (isParseableDimension(input.icons.grid)) {
+            resolvedGrid = parseDimension(input.icons.grid);
+            symbolTable.set('icons.grid', resolvedGrid);
+          } else {
+            findings.push({
+              severity: 'error',
+              path: 'icons.grid',
+              message: `'${input.icons.grid}' is not a valid dimension.`,
+            });
+          }
+        }
+
+        let resolvedColor: ResolvedColor | undefined;
+        if (typeof input.icons.color === 'string') {
+          const raw = input.icons.color;
+          if (isTokenReference(raw)) {
+            const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
+            if (resolved !== null && typeof resolved === 'object' && 'type' in resolved && resolved.type === 'color') {
+              resolvedColor = resolved as ResolvedColor;
+              symbolTable.set('icons.color', resolvedColor);
+            } else {
+              findings.push({
+                severity: 'error',
+                path: 'icons.color',
+                message: `Could not resolve color reference '${raw}'.`,
+              });
+            }
+          } else if (isValidColor(raw)) {
+            resolvedColor = parseColor(raw);
+            symbolTable.set('icons.color', resolvedColor);
+          } else {
+            findings.push({
+              severity: 'error',
+              path: 'icons.color',
+              message: `'${raw}' is not a valid color or token reference.`,
+            });
+          }
+        }
+
+        let resolvedStrokeWidth: number | undefined;
+        if (input.icons.strokeWidth !== undefined) {
+          const sw = input.icons.strokeWidth;
+          if (typeof sw === 'number') {
+            resolvedStrokeWidth = sw;
+          } else if (typeof sw === 'string') {
+            const n = Number(sw);
+            if (!Number.isNaN(n)) {
+              resolvedStrokeWidth = n;
+            } else {
+              findings.push({
+                severity: 'error',
+                path: 'icons.strokeWidth',
+                message: `'${sw}' is not a valid number.`,
+              });
+            }
+          }
+        }
+
+        icons = {
+          type: 'icons',
+          library: input.icons.library,
+          style: input.icons.style,
+          strokeWidth: resolvedStrokeWidth,
+          grid: resolvedGrid,
+          size: sizeMap,
+          color: resolvedColor,
+        };
+      }
+
       return {
         designSystem: {
           name: input.name,
@@ -207,6 +306,7 @@ export class ModelHandler implements ModelSpec {
           rounded,
           spacing,
           components,
+          icons,
           symbolTable,
           sections: input.sections,
         },

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -60,7 +60,17 @@ export interface ResolvedTypography {
   fontVariation?: string | undefined;
 }
 
-export type ResolvedValue = ResolvedColor | ResolvedDimension | ResolvedTypography | string;
+export interface ResolvedIcons {
+  type: 'icons';
+  library?: string | undefined;
+  style?: string | undefined;
+  strokeWidth?: number | undefined;
+  grid?: ResolvedDimension | undefined;
+  size: Map<string, ResolvedDimension>;
+  color?: ResolvedColor | undefined;
+}
+
+export type ResolvedValue = ResolvedColor | ResolvedDimension | ResolvedTypography | ResolvedIcons | string;
 
 // ── Re-exported from spec-config (single source of truth) ─────────
 export const VALID_TYPOGRAPHY_PROPS = _VALID_TYPOGRAPHY_PROPS;
@@ -75,6 +85,8 @@ export interface DesignSystemState {
   rounded: Map<string, ResolvedDimension>;
   spacing: Map<string, ResolvedDimension>;
   components: Map<string, ComponentDef>;
+  /** Icons token group (single instance, not a map). */
+  icons?: ResolvedIcons | undefined;
   /** Flat lookup: "colors.primary" → ResolvedColor */
   symbolTable: Map<string, ResolvedValue>;
   /** Markdown heading names found in the document */

--- a/packages/cli/src/linter/parser/handler.test.ts
+++ b/packages/cli/src/linter/parser/handler.test.ts
@@ -154,3 +154,30 @@ Some markdown text with no YAML blocks.
     });
   });
 });
+
+describe('icons passthrough', () => {
+  it('parses icons top-level block from frontmatter', () => {
+    const content = `---
+name: Test
+icons:
+  library: Lucide
+  style: outlined
+  strokeWidth: 1.5
+  size:
+    sm: 16px
+    md: 24px
+  color: "{colors.on-surface}"
+---
+
+## Colors
+Some text.
+`;
+    const handler = new ParserHandler();
+    const result = handler.execute({ content });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.icons).toBeDefined();
+    expect(result.data.icons!.library).toBe('Lucide');
+    expect(result.data.icons!.size!.md).toBe('24px');
+  });
+});

--- a/packages/cli/src/linter/parser/handler.ts
+++ b/packages/cli/src/linter/parser/handler.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import YAML from 'yaml';
-import type { ParserSpec, ParserInput, ParserResult, ParsedDesignSystem, SourceLocation } from './spec.js';
+import type { ParserSpec, ParserInput, ParserResult, ParsedDesignSystem, IconsBlock, SourceLocation } from './spec.js';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkFrontmatter from 'remark-frontmatter';
@@ -198,6 +198,7 @@ export class ParserHandler implements ParserSpec {
       rounded: raw['rounded'] as Record<string, string> | undefined,
       spacing: raw['spacing'] as Record<string, string> | undefined,
       components: raw['components'] as Record<string, Record<string, string>> | undefined,
+      icons: raw['icons'] as IconsBlock | undefined,
       sourceMap,
       sections,
       documentSections,

--- a/packages/cli/src/linter/parser/spec.ts
+++ b/packages/cli/src/linter/parser/spec.ts
@@ -37,6 +37,15 @@ export interface SourceLocation {
   block: 'frontmatter' | number;
 }
 
+export interface IconsBlock {
+  library?: string | undefined;
+  style?: string | undefined;
+  strokeWidth?: number | string | undefined;
+  grid?: string | undefined;
+  size?: Record<string, string> | undefined;
+  color?: string | undefined;
+}
+
 /** Raw, unresolved parsed output — mirrors the YAML schema */
 export interface ParsedDesignSystem {
   name?: string | undefined;
@@ -46,6 +55,7 @@ export interface ParsedDesignSystem {
   rounded?: Record<string, string> | undefined;
   spacing?: Record<string, string> | undefined;
   components?: Record<string, Record<string, string>> | undefined;
+  icons?: IconsBlock | undefined;
   sourceMap: Map<string, SourceLocation>;
   /** Markdown heading names found in the document (e.g., 'Colors', 'Typography') */
   sections?: string[] | undefined;

--- a/packages/cli/src/linter/spec-config.test.ts
+++ b/packages/cli/src/linter/spec-config.test.ts
@@ -22,6 +22,7 @@ import {
   TYPOGRAPHY_PROPERTIES,
   COMPONENT_SUB_TOKENS,
   CORE_COLOR_ROLES,
+  ICON_STYLES,
   RECOMMENDED_TOKENS,
   EXAMPLES,
   CANONICAL_ORDER,
@@ -204,5 +205,26 @@ describe('spec-config derived constants', () => {
     for (const [alias, canonical] of Object.entries(SECTION_ALIASES)) {
       expect(CANONICAL_ORDER).toContain(canonical);
     }
+  });
+});
+
+describe('spec-config icons additions', () => {
+  it('Iconography appears in canonical section order between Shapes and Components', () => {
+    const idxShapes = CANONICAL_ORDER.indexOf('Shapes');
+    const idxIcons = CANONICAL_ORDER.indexOf('Iconography');
+    const idxComponents = CANONICAL_ORDER.indexOf('Components');
+    expect(idxShapes).toBeGreaterThan(-1);
+    expect(idxIcons).toBe(idxShapes + 1);
+    expect(idxComponents).toBe(idxIcons + 1);
+  });
+
+  it('ICON_STYLES enum exposes the five canonical styles', () => {
+    expect(ICON_STYLES).toEqual(['outlined', 'filled', 'rounded', 'sharp', 'duotone']);
+  });
+
+  it('EXAMPLES.icons is validated and present', () => {
+    expect(EXAMPLES.icons).toBeDefined();
+    expect(EXAMPLES.icons.library).toBe('Lucide');
+    expect(EXAMPLES.icons.size?.md).toBe('24px');
   });
 });

--- a/packages/cli/src/linter/spec-config.ts
+++ b/packages/cli/src/linter/spec-config.ts
@@ -38,6 +38,15 @@ const PropertyDefSchema = z.object({
   description: z.string().optional(),
 });
 
+const IconsExampleSchema = z.object({
+  library: z.string(),
+  style: z.string().optional(),
+  strokeWidth: z.union([z.number(), z.string()]).optional(),
+  grid: z.string().optional(),
+  size: z.record(z.string(), z.string()).optional(),
+  color: z.string().optional(),
+});
+
 const ConfigSchema = z.object({
   version: z.string(),
   units: z.array(z.string()).min(1),
@@ -48,11 +57,13 @@ const ConfigSchema = z.object({
   typography_properties: z.array(PropertyDefSchema).min(1),
   component_sub_tokens: z.array(PropertyDefSchema).min(1),
   color_roles: z.array(z.string()).min(1),
+  icon_styles: z.array(z.string()).min(1),
   recommended_tokens: z.record(z.string(), z.array(z.string())),
   examples: z.object({
     colors: z.record(z.string(), z.string()),
     typography: z.record(z.string(), z.record(z.string(), z.union([z.string(), z.number()]))),
     components: z.record(z.string(), z.record(z.string(), z.string())),
+    icons: IconsExampleSchema,
   }),
 });
 
@@ -130,6 +141,9 @@ export const COMPONENT_SUB_TOKENS: readonly ComponentSubTokenDef[] = config.comp
 /** Core color roles that every design system should define. */
 export const CORE_COLOR_ROLES = config.color_roles;
 
+/** The enum of canonical icon style values. */
+export const ICON_STYLES: readonly string[] = config.icon_styles;
+
 /** Non-normative recommended token names, organized by category. */
 export const RECOMMENDED_TOKENS = config.recommended_tokens;
 
@@ -169,6 +183,7 @@ export interface SpecConfig {
   TYPOGRAPHY_PROPERTIES: typeof TYPOGRAPHY_PROPERTIES;
   COMPONENT_SUB_TOKENS: typeof COMPONENT_SUB_TOKENS;
   CORE_COLOR_ROLES: typeof CORE_COLOR_ROLES;
+  ICON_STYLES: typeof ICON_STYLES;
   RECOMMENDED_TOKENS: typeof RECOMMENDED_TOKENS;
   EXAMPLES: typeof EXAMPLES;
 }
@@ -181,6 +196,7 @@ export const SPEC_CONFIG: SpecConfig = {
   TYPOGRAPHY_PROPERTIES,
   COMPONENT_SUB_TOKENS,
   CORE_COLOR_ROLES,
+  ICON_STYLES,
   RECOMMENDED_TOKENS,
   EXAMPLES,
 };

--- a/packages/cli/src/linter/spec-config.yaml
+++ b/packages/cli/src/linter/spec-config.yaml
@@ -36,6 +36,7 @@ sections:
     aliases:
       - Elevation
   - canonical: Shapes
+  - canonical: Iconography
   - canonical: Components
   - canonical: "Do's and Don'ts"
 
@@ -77,6 +78,13 @@ component_sub_tokens:
   - name: width
     type: Dimension
 
+icon_styles:
+  - outlined
+  - filled
+  - rounded
+  - sharp
+  - duotone
+
 color_roles:
   - primary
   - secondary
@@ -109,6 +117,16 @@ recommended_tokens:
     - lg
     - xl
     - full
+  icon-styles:
+    - outlined
+    - filled
+    - rounded
+    - sharp
+    - duotone
+  icon-sizes:
+    - sm
+    - md
+    - lg
 
 examples:
   colors:
@@ -142,3 +160,13 @@ examples:
       padding: 12px
     button-primary-hover:
       backgroundColor: "{colors.primary-70}"
+  icons:
+    library: "Lucide"
+    style: "outlined"
+    strokeWidth: 1.5
+    grid: "24px"
+    size:
+      sm: "16px"
+      md: "24px"
+      lg: "32px"
+    color: "{colors.on-surface}"

--- a/packages/cli/src/linter/spec-gen/compiler.test.ts
+++ b/packages/cli/src/linter/spec-gen/compiler.test.ts
@@ -74,7 +74,6 @@ describe('compileMdx', () => {
       componentSubTokenList: () => renderers.componentSubTokenList(cfg),
       recommendedTokens: () => renderers.recommendedTokens(cfg),
       iconsExample: () => renderers.iconsExample(cfg),
-      iconStyleEnumList: () => renderers.iconStyleEnumList(cfg),
     };
 
     const result = await compileMdx(source, scope);

--- a/packages/cli/src/linter/spec-gen/compiler.test.ts
+++ b/packages/cli/src/linter/spec-gen/compiler.test.ts
@@ -73,6 +73,8 @@ describe('compileMdx', () => {
       sectionOrderList: () => renderers.sectionOrderList(cfg),
       componentSubTokenList: () => renderers.componentSubTokenList(cfg),
       recommendedTokens: () => renderers.recommendedTokens(cfg),
+      iconsExample: () => renderers.iconsExample(cfg),
+      iconStyleEnumList: () => renderers.iconStyleEnumList(cfg),
     };
 
     const result = await compileMdx(source, scope);

--- a/packages/cli/src/linter/spec-gen/generate.ts
+++ b/packages/cli/src/linter/spec-gen/generate.ts
@@ -49,6 +49,8 @@ async function main() {
     sectionOrderList: () => renderers.sectionOrderList(cfg),
     componentSubTokenList: () => renderers.componentSubTokenList(cfg),
     recommendedTokens: () => renderers.recommendedTokens(cfg),
+    iconsExample: () => renderers.iconsExample(cfg),
+    iconStyleEnumList: () => renderers.iconStyleEnumList(cfg),
   };
 
   const generated = await compileMdx(source, scope);

--- a/packages/cli/src/linter/spec-gen/generate.ts
+++ b/packages/cli/src/linter/spec-gen/generate.ts
@@ -50,7 +50,6 @@ async function main() {
     componentSubTokenList: () => renderers.componentSubTokenList(cfg),
     recommendedTokens: () => renderers.recommendedTokens(cfg),
     iconsExample: () => renderers.iconsExample(cfg),
-    iconStyleEnumList: () => renderers.iconStyleEnumList(cfg),
   };
 
   const generated = await compileMdx(source, scope);

--- a/packages/cli/src/linter/spec-gen/renderers.test.ts
+++ b/packages/cli/src/linter/spec-gen/renderers.test.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { iconsExample, iconStyleEnumList } from './renderers.js';
+import { SPEC_CONFIG } from '../spec-config.js';
+
+describe('iconsExample renderer', () => {
+  it('renders the icons YAML block with library, style, strokeWidth, grid, size map, color', () => {
+    const output = iconsExample(SPEC_CONFIG);
+    expect(output).toContain('```yaml');
+    expect(output).toContain('icons:');
+    expect(output).toContain('library: "Lucide"');
+    expect(output).toContain('style: "outlined"');
+    expect(output).toContain('strokeWidth: 1.5');
+    expect(output).toContain('grid: "24px"');
+    expect(output).toContain('size:');
+    expect(output).toContain('md: "24px"');
+    expect(output).toContain('color: "{colors.on-surface}"');
+  });
+});
+
+describe('iconStyleEnumList renderer', () => {
+  it('renders the canonical icon styles as comma-separated backticked tokens', () => {
+    const output = iconStyleEnumList(SPEC_CONFIG);
+    expect(output).toBe('`outlined`, `filled`, `rounded`, `sharp`, `duotone`');
+  });
+});

--- a/packages/cli/src/linter/spec-gen/renderers.test.ts
+++ b/packages/cli/src/linter/spec-gen/renderers.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, it, expect } from 'bun:test';
-import { iconsExample, iconStyleEnumList } from './renderers.js';
+import { iconsExample } from './renderers.js';
 import { SPEC_CONFIG } from '../spec-config.js';
 
 describe('iconsExample renderer', () => {
@@ -28,12 +28,5 @@ describe('iconsExample renderer', () => {
     expect(output).toContain('size:');
     expect(output).toContain('md: "24px"');
     expect(output).toContain('color: "{colors.on-surface}"');
-  });
-});
-
-describe('iconStyleEnumList renderer', () => {
-  it('renders the canonical icon styles as comma-separated backticked tokens', () => {
-    const output = iconStyleEnumList(SPEC_CONFIG);
-    expect(output).toBe('`outlined`, `filled`, `rounded`, `sharp`, `duotone`');
   });
 });

--- a/packages/cli/src/linter/spec-gen/renderers.ts
+++ b/packages/cli/src/linter/spec-gen/renderers.ts
@@ -121,3 +121,26 @@ export function recommendedTokens(config: SpecConfig): string {
     })
     .join('\n\n');
 }
+
+/** Icons YAML example. */
+export function iconsExample(config: SpecConfig): string {
+  const icons = config.EXAMPLES.icons;
+  const lines: string[] = ['icons:'];
+  if (icons.library !== undefined) lines.push(`  library: "${icons.library}"`);
+  if (icons.style !== undefined) lines.push(`  style: "${icons.style}"`);
+  if (icons.strokeWidth !== undefined) lines.push(`  strokeWidth: ${icons.strokeWidth}`);
+  if (icons.grid !== undefined) lines.push(`  grid: "${icons.grid}"`);
+  if (icons.size !== undefined) {
+    lines.push('  size:');
+    for (const [k, v] of Object.entries(icons.size)) {
+      lines.push(`    ${k}: "${v}"`);
+    }
+  }
+  if (icons.color !== undefined) lines.push(`  color: "${icons.color}"`);
+  return yamlBlock(lines);
+}
+
+/** Comma-separated backticked list of canonical icon styles. */
+export function iconStyleEnumList(config: SpecConfig): string {
+  return config.ICON_STYLES.map(s => `\`${s}\``).join(', ');
+}

--- a/packages/cli/src/linter/spec-gen/renderers.ts
+++ b/packages/cli/src/linter/spec-gen/renderers.ts
@@ -139,8 +139,3 @@ export function iconsExample(config: SpecConfig): string {
   if (icons.color !== undefined) lines.push(`  color: "${icons.color}"`);
   return yamlBlock(lines);
 }
-
-/** Comma-separated backticked list of canonical icon styles. */
-export function iconStyleEnumList(config: SpecConfig): string {
-  return config.ICON_STYLES.map(s => `\`${s}\``).join(', ');
-}

--- a/packages/cli/src/linter/spec-gen/spec.mdx
+++ b/packages/cli/src/linter/spec-gen/spec.mdx
@@ -218,6 +218,39 @@ rounded:
   full: 9999px
 ```
 
+## Iconography
+
+This section defines the icon library, style, and size scale used across the product.
+
+Example:
+
+```markdown
+## Iconography
+
+Icons use **Lucide** in its outlined style at a 1.5 stroke weight, echoing
+the calm, linear rhythm of the typography. Icons render on a 24px grid and
+inherit `on-surface` color by default.
+
+- **Small (16px):** Inline with body text or dense tables.
+- **Medium (24px):** Default for buttons, navigation, and form fields.
+- **Large (32px):** Feature tiles and empty states.
+```
+
+### Design Tokens
+
+The `icons` section defines a single token group (not a map) describing the
+icon library in use, its style variant, stroke weight, source grid, render
+sizes, and default color.
+
+{iconsExample()}
+
+- `library` (string) — the icon set in use (e.g., "Lucide", "Heroicons", "Material Symbols"). Agents resolve the string to an import.
+- `style` (enum, optional) — one of: {iconStyleEnumList()}. Unknown values are preserved with a warning.
+- `strokeWidth` (number, optional) — for stroke-based libraries (Lucide, Tabler, Feather). Font-based libraries (e.g., Material Symbols with its 100–700 weight axis) map this agent-side.
+- `grid` (Dimension, optional) — the source viewBox unit (Radix 15, Phosphor 256, most others 24). Distinct from `size.*`, which is the CSS render size.
+- `size` (map\<string, Dimension\>, optional) — named render sizes.
+- `color` (Color or token reference, optional) — default icon color; inherits via CSS `currentColor` unless explicitly set.
+
 ## Components
 
 This section provides style guidance for component atoms within the design system. The following are common component types. Design systems are encouraged to define additional components relevant to their domain.
@@ -271,7 +304,7 @@ When a DESIGN.md consumer encounters content not defined by this spec:
 
 | Scenario | Behavior | Example |
 |---|---|---|
-| Unknown section heading | Preserve; do not error | `## Iconography` |
+| Unknown section heading | Preserve; do not error | `## Illustrations` |
 | Unknown color token name | Accept if value is valid | `surface-container-high: '#ede7dd'` |
 | Unknown typography token name | Accept as valid typography | `telemetry-data` |
 | Unknown spacing value | Accept; store as string if not a valid dimension | `grid-columns: '5'` |

--- a/packages/cli/src/linter/spec-gen/spec.mdx
+++ b/packages/cli/src/linter/spec-gen/spec.mdx
@@ -245,7 +245,7 @@ sizes, and default color.
 {iconsExample()}
 
 - `library` (string) — the icon set in use (e.g., "Lucide", "Heroicons", "Material Symbols"). Agents resolve the string to an import.
-- `style` (enum, optional) — one of: {iconStyleEnumList()}. Unknown values are preserved with a warning.
+- `style` (enum, optional) — one of: `outlined`, `filled`, `rounded`, `sharp`, `duotone`. Unknown values are preserved with a warning.
 - `strokeWidth` (number, optional) — for stroke-based libraries (Lucide, Tabler, Feather). Font-based libraries (e.g., Material Symbols with its 100–700 weight axis) map this agent-side.
 - `grid` (Dimension, optional) — the source viewBox unit (Radix 15, Phosphor 256, most others 24). Distinct from `size.*`, which is the CSS render size.
 - `size` (map\<string, Dimension\>, optional) — named render sizes.


### PR DESCRIPTION
# feat(spec): add Iconography section and `icons.*` tokens

This PR adds an `## Iconography` section and `icons.*` token group to the
DESIGN.md spec, so design systems can formally declare icon library, style
variant, stroke weight, grid, size scale, and default color.

Fixes #41

## What's added

- **Spec section** — new `## Iconography` inserted between `Shapes` and
  `Components` in the canonical section order.
- **Token group** — `icons.library`, `icons.style`, `icons.strokeWidth`,
  `icons.grid`, `icons.size.*`, `icons.color`.
- **Recommended token names** — `sm | md | lg` size scale,
  `outlined | filled | rounded | sharp | duotone` style values, added
  non-normatively to the existing recommended names list.
- **Linter** — enum validation on `style` (warn on unknown, matching existing
  spec behavior), Dimension validation on `size.*` and `grid`, number
  validation on `strokeWidth`, cross-reference validation on `color` reusing
  the existing token-ref resolver in `packages/cli/src/linter/linter/`.

## Files

- `packages/cli/src/linter/spec-config.yaml` — source-of-truth schema addition
- `packages/cli/src/linter/spec-config.test.ts` — schema tests
- `packages/cli/src/linter/model/` — type definitions for the `icons` group
- `packages/cli/src/linter/parser/` — YAML frontmatter parsing for `icons`
- `packages/cli/src/linter/fixtures/` — valid and invalid fixtures
- `docs/spec.md` — regenerated via `bun run spec:gen`
- `examples/paws-and-paths/DESIGN.md` — demo usage on one existing example
- **No changes** to `packages/cli/src/linter/spec-gen/`; the icons section
  renders via the existing section template.

## Consumer Behavior table update

`docs/spec.md`'s "Consumer Behavior for Unknown Content" table previously
used `## Iconography` as its example of an unknown section. Since that
section is now defined, the example row has been swapped to
`## Illustrations` to avoid self-contradiction.

## Backwards compatibility

No breaking changes. Existing DESIGN.md files without an `icons` block or
`## Iconography` section parse and lint identically. No spec version bump
— the spec is in `alpha` and additive schema changes are in-scope.

## Out of scope for this PR

Duotone `secondaryColor`, multi-library maps, separate `weight` axis, and
optical-size variant selection are deferred; see the parent issue for the
per-case rationale.

Icon tokens are spec-only in v1: `export` (Tailwind, DTCG) passes icon
tokens through unchanged, since neither format carries icon metadata.
`import` (#40) is a no-op for icons for the same reason.

## Testing

- Unit tests cover: valid icon tokens, invalid `style` enum value (warning
  only), unresolved `color` token reference (error), malformed `size.*`
  Dimension, malformed `grid` Dimension, non-numeric `strokeWidth`, and all
  optional fields omitted.
- Integration: `paws-and-paths` with a populated `icons` block lints clean.
- Export commands verified to pass `icons.*` tokens through unchanged on the
  updated example (no Tailwind/DTCG surface for icons in v1).
