### PR TITLE
fix: lint --format markdown emits literal [object Object]

### DIFF
--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { formatOutput } from './utils.js';
+
+describe('formatOutput — markdown', () => {
+  it('renders lint output as readable markdown (regression: must not contain [object Object])', () => {
+    const lintOutput = {
+      findings: [
+        {
+          severity: 'warning',
+          path: 'colors.error',
+          message: "'error' is defined but never referenced by any component.",
+        },
+        {
+          severity: 'info',
+          message: 'Design system defines 47 colors, 6 typography scales.',
+        },
+      ],
+      summary: { errors: 0, warnings: 1, infos: 1 },
+    };
+
+    const out = formatOutput(lintOutput, { format: 'markdown' });
+
+    // The bug we're fixing: `# ${obj.summary}` template-literals an object → "[object Object]".
+    expect(out).not.toContain('[object Object]');
+
+    // Sensible structure: a heading, the counts, and the finding messages.
+    expect(out).toMatch(/^#\s/m);                     // has at least one heading
+    expect(out).toContain('errors');                  // counts surface (key or label)
+    expect(out).toContain('warnings');
+    expect(out).toContain("'error' is defined");      // first finding message
+    expect(out).toContain('47 colors');               // info finding message
+  });
+
+  it('also accepts --format md as alias for markdown', () => {
+    const lintOutput = {
+      findings: [],
+      summary: { errors: 0, warnings: 0, infos: 0 },
+    };
+    const out = formatOutput(lintOutput, { format: 'md' });
+    expect(out).not.toContain('[object Object]');
+    expect(out).toMatch(/^#\s/m);
+  });
+
+  it('still defaults to JSON when format is unspecified', () => {
+    const data = { findings: [], summary: { errors: 0, warnings: 0, infos: 0 } };
+    const out = formatOutput(data, {});
+    expect(() => JSON.parse(out)).not.toThrow();
+  });
+});

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -54,8 +54,15 @@ export function formatOutput(data: unknown, args: { format?: string }): string {
 function formatAsMarkdown(data: unknown): string {
   if (typeof data === 'object' && data !== null) {
     const obj = data as Record<string, unknown>;
+
+    // Lint report shape: { findings: Finding[], summary: { errors, warnings, infos } }
+    if (Array.isArray(obj.findings) && isLintSummary(obj.summary)) {
+      return formatLintAsMarkdown(obj.findings as LintFinding[], obj.summary as LintSummary);
+    }
+
+    // Legacy fixer/diff shape: { summary: string, details?: ..., patches?: ... }
     let result = '';
-    if (obj.summary) {
+    if (typeof obj.summary === 'string') {
       result += `# ${obj.summary}\n\n`;
     }
     if (obj.details) {
@@ -71,6 +78,53 @@ function formatAsMarkdown(data: unknown): string {
     return result || formatAsText(data);
   }
   return String(data);
+}
+
+interface LintSummary {
+  errors: number;
+  warnings: number;
+  infos: number;
+}
+
+interface LintFinding {
+  severity: string;
+  path?: string;
+  message: string;
+}
+
+function isLintSummary(value: unknown): value is LintSummary {
+  if (typeof value !== 'object' || value === null) return false;
+  const s = value as Record<string, unknown>;
+  return (
+    typeof s.errors === 'number' &&
+    typeof s.warnings === 'number' &&
+    typeof s.infos === 'number'
+  );
+}
+
+function formatLintAsMarkdown(findings: LintFinding[], summary: LintSummary): string {
+  const lines: string[] = [];
+  lines.push('# Lint Report');
+  lines.push('');
+  lines.push(
+    `**${summary.errors} errors**, **${summary.warnings} warnings**, **${summary.infos} infos**`,
+  );
+  lines.push('');
+
+  if (findings.length === 0) {
+    lines.push('No findings.');
+    lines.push('');
+    return lines.join('\n');
+  }
+
+  lines.push('## Findings');
+  lines.push('');
+  for (const f of findings) {
+    const path = f.path ? ` \`${f.path}\`` : '';
+    lines.push(`- **${f.severity}**${path}: ${f.message}`);
+  }
+  lines.push('');
+  return lines.join('\n');
 }
 
 function formatAsText(data: unknown, indent = 0): string {


### PR DESCRIPTION
## Summary

`lint --format markdown` currently emits a literal `# [object Object]` instead of a readable report. `formatAsMarkdown` in `packages/cli/src/utils.ts` template-literaled `obj.summary` directly, which works for the legacy fixer shape (`{ summary: string }`) but breaks on lint output (`{ summary: { errors, warnings, infos } }`) — coercing the object to its `[object Object]` string.

This PR detects the lint shape and renders a proper markdown report with severity counts and a bulleted findings list. The legacy path is preserved for any existing fixer/diff shapes.

## Reproduction (before)

```
$ npx @google/design.md@0.1.1 lint examples/atmospheric-glass/DESIGN.md --format markdown
# [object Object]
```

## After

```
$ design.md lint examples/atmospheric-glass/DESIGN.md --format markdown
# Lint Report

**0 errors**, **43 warnings**, **1 infos**

## Findings

- **warning** `colors.surface`: 'surface' is defined but never referenced by any component.
- **warning** `colors.surface-dim`: 'surface-dim' is defined but never referenced by any component.
...
```

## Implementation

- Detect the lint shape (`Array.isArray(obj.findings) && isLintSummary(obj.summary)` where the summary has numeric `errors`/`warnings`/`infos`) and route to a dedicated `formatLintAsMarkdown` renderer.
- Gate the legacy `obj.summary` branch on `typeof obj.summary === 'string'` so previous behavior for fixer/diff shapes is unchanged.
- Inline `LintSummary` and `LintFinding` types live in `utils.ts` to avoid a circular dependency on the linter package.

## Tests

New `packages/cli/src/utils.test.ts` with three cases:

- Lint-shape input must not contain `[object Object]` and must produce a headed markdown report containing the finding messages (regression).
- `--format md` alias works the same as `markdown`.
- Default (no format) still returns valid JSON.

## Test plan

- [x] `bun test packages/cli/src/utils.test.ts` — 3/3 pass
- [x] `bun test` (full workspace) — 206/206 pass
- [x] Manual smoke: `bun run packages/cli/src/index.ts lint examples/atmospheric-glass/DESIGN.md --format markdown` produces a clean `# Lint Report`

## Notes

- I have not yet signed the Google CLA at https://cla.developers.google.com/ — happy to sign once this is reviewed.
- TDD trail: failing test was committed first, then the fix. Diff is intentionally small and self-contained.
