### PR TITLE
docs(ci): clarify npm install on Windows; add npm registry smoke test on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,3 +52,22 @@ jobs:
         npx design.md lint DESIGN.md
         node -e "import('@google/design.md/linter').then(m => console.log('OK:', Object.keys(m).length, 'exports'))"
 
+  npm-registry-smoke-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+        registry-url: https://registry.npmjs.org
+
+    - name: Install @google/design.md from the public npm registry
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "$RUNNER_TEMP/npm-registry-smoke"
+        cd "$RUNNER_TEMP/npm-registry-smoke"
+        npm init -y
+        npm install "@google/design.md@latest"
+        node node_modules/@google/design.md/dist/index.js spec --rules-only --format json > /dev/null
+        node -e "import('@google/design.md/linter').then(m => console.log('OK:', Object.keys(m).length, 'exports'))"
+

--- a/README.md
+++ b/README.md
@@ -179,11 +179,29 @@ Variants (hover, active, pressed) are expressed as separate component entries wi
 npm install @google/design.md
 ```
 
-Or run directly:
+On **Windows**, quote the package name if your shell treats `@` specially (PowerShell, some terminals):
+
+```bash
+npm install "@google/design.md"
+```
+
+Or run directly (always resolves from the public npm registry):
 
 ```bash
 npx @google/design.md lint DESIGN.md
 ```
+
+#### `npm error ENOVERSIONS` (“No versions available for @google/design.md”)
+
+The CLI is published as [`@google/design.md` on npm](https://www.npmjs.com/package/@google/design.md). `ENOVERSIONS` almost always means npm is not querying the public registry (custom `registry=` in `.npmrc`, a corporate mirror that has not synced this package, or a misconfigured `@google:registry` for the `@google` scope).
+
+Check your effective registry:
+
+```bash
+npm config get registry
+```
+
+For a normal install from the internet it should be `https://registry.npmjs.org/`. After fixing config, retry with `npm cache clean --force` if a stale 404 was cached.
 
 All commands accept a file path or `-` for stdin. Output defaults to JSON.
 


### PR DESCRIPTION
Related to #55.

Some users report `npm error ENOVERSIONS` / “No versions available for @google/design.md” on Windows. The package is published on the public npm registry; that error usually indicates a non-default registry, mirror, or scope config.

### Changes
- **README:** Document quoting `npm install "@google/design.md"` on Windows, and add a short troubleshooting section for `ENOVERSIONS` (registry / `.npmrc`, cache).
- **CI:** Add a `windows-latest` job that installs `@google/design.md@latest` from `https://registry.npmjs.org` and runs a minimal CLI + `linter` subpath import smoke test.

### Notes
- Does not change runtime behavior of the CLI.