### PR TITLE
chore: update checkout action version from v4 to v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     
     - uses: oven-sh/setup-bun@v2
       with:


### PR DESCRIPTION
v4 is unsupported and v6 is safer.
https://github.com/actions/checkout/releases