### PR TITLE
fix: allow Tailwind v4 digit-leading token names

### DIFF
--- a/packages/cli/src/linter/tailwind/v4/handler.test.ts
+++ b/packages/cli/src/linter/tailwind/v4/handler.test.ts
@@ -144,13 +144,15 @@ describe('TailwindV4EmitterHandler', () => {
       expect(result.error.message).toContain('primary.surface');
     });
 
-    it('fails when a spacing token name starts with a digit', () => {
+    it('allows Tailwind-style dimension token names that start with a digit', () => {
       const state = buildState({});
-      state.spacing.set('1bad', { type: 'dimension', value: 4, unit: 'px' });
+      state.spacing.set('2xs', { type: 'dimension', value: 2, unit: 'px' });
+      state.rounded.set('4xl', { type: 'dimension', value: 32, unit: 'px' });
       const result = emitter.execute(state);
-      expect(result.success).toBe(false);
-      if (result.success) return;
-      expect(result.error.code).toBe('INVALID_TOKEN_NAME');
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.theme.spacing?.['2xs']).toBe('2px');
+      expect(result.data.theme.borderRadius?.['4xl']).toBe('32px');
     });
 
     it('fails when a token name contains a space', () => {

--- a/packages/cli/src/linter/tailwind/v4/handler.ts
+++ b/packages/cli/src/linter/tailwind/v4/handler.ts
@@ -15,7 +15,7 @@
 import type { TailwindV4EmitterSpec, TailwindV4EmitterResult, TailwindV4ThemeData } from './spec.js';
 import type { DesignSystemState, ResolvedDimension } from '../../model/spec.js';
 
-const VALID_TOKEN_NAME = /^[a-zA-Z][a-zA-Z0-9-]*$/;
+const VALID_TOKEN_NAME = /^[a-zA-Z0-9][a-zA-Z0-9-]*$/;
 
 /**
  * Pure function mapping DesignSystemState → Tailwind v4 theme data.
@@ -39,7 +39,7 @@ export class TailwindV4EmitterHandler implements TailwindV4EmitterSpec {
           success: false,
           error: {
             code: 'INVALID_TOKEN_NAME',
-            message: `Token name "${name}" is not a valid CSS identifier for Tailwind v4 export (must match /^[a-zA-Z][a-zA-Z0-9-]*$/).`,
+            message: `Token name "${name}" is not a valid CSS identifier for Tailwind v4 export (must match /^[a-zA-Z0-9][a-zA-Z0-9-]*$/).`,
           },
         };
       }


### PR DESCRIPTION
## Summary
- relax the Tailwind v4 token-name validator so names like \\2xs\\ and \\4xl\\ can export
- keep rejecting dotted and space-containing token names
- update the Tailwind v4 emitter regression test for digit-leading spacing and radius tokens

Fixes #71.

## Verification
- RED: \\
px bun test packages/cli/src/linter/tailwind/v4/handler.test.ts\\ failed on the new digit-leading token test before the handler change
- GREEN: \\
px bun test packages/cli/src/linter/tailwind/v4/handler.test.ts\\ -> 9 pass, 0 fail
- \\
px bun test packages/cli/src/linter/tailwind/v4\\ -> 17 pass, 0 fail
- \\git diff --check\\

## Note
- \\./node_modules/.bin/tsc.exe --project packages/cli/tsconfig.build.json --noEmit\\ is blocked locally by dependency declaration errors in \\un-types\\ under the transient \\
px bun\\ install before reaching this change.