### PR TITLE
feat: add motion tokens (durations, easings, transitions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ rounded:
   <scale-level>: <Dimension>
 spacing:
   <scale-level>: <Dimension | number>
+motion:
+  duration:
+    <token-name>: <Duration>
+  easing:
+    <token-name>: <CubicBezier>
+  transition:
+    <token-name>:
+      duration: <Duration | token reference>
+      easing: <CubicBezier | token reference>
 components:
   <component-name>:
     <token-name>: <string | token reference>
@@ -124,6 +133,8 @@ components:
 |:-----|:-------|:--------|
 | Color | `#` + hex (sRGB) | `"#1A1C1E"` |
 | Dimension | number + unit (`px`, `em`, `rem`) | `48px`, `-0.02em` |
+| Duration | number + unit (`ms`, `s`) | `150ms`, `0.4s` |
+| CubicBezier | 4-element array `[x1, y1, x2, y2]` | `[0.2, 0, 0, 1]` |
 | Token Reference | `{path.to.token}` | `{colors.primary}` |
 | Typography | object with `fontFamily`, `fontSize`, `fontWeight`, `lineHeight`, `letterSpacing`, `fontFeature`, `fontVariation` | See example above |
 
@@ -139,8 +150,9 @@ Sections use `##` headings. They can be omitted, but those present must appear i
 | 4 | Layout | Layout & Spacing |
 | 5 | Elevation & Depth | Elevation |
 | 6 | Shapes | |
-| 7 | Components | |
-| 8 | Do's and Don'ts | |
+| 7 | Motion | |
+| 8 | Components | |
+| 9 | Do's and Don'ts | |
 
 ### Component Tokens
 
@@ -157,7 +169,7 @@ components:
     backgroundColor: "{colors.tertiary-container}"
 ```
 
-Valid component properties: `backgroundColor`, `textColor`, `typography`, `rounded`, `padding`, `size`, `height`, `width`.
+Valid component properties: `backgroundColor`, `textColor`, `typography`, `rounded`, `padding`, `size`, `height`, `width`, `transition`.
 
 Variants (hover, active, pressed) are expressed as separate component entries with a related key name.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -52,6 +52,15 @@ rounded:
   <scale-level>: <Dimension>
 spacing:
   <scale-level>: <Dimension | number>
+motion:
+  duration:
+    <token-name>: <Duration>
+  easing:
+    <token-name>: <CubicBezier>
+  transition:
+    <token-name>:
+      duration: <Duration | token reference>
+      easing: <CubicBezier | token reference>
 components:
   <component-name>:
     <token-name>: <string|token reference>
@@ -73,6 +82,10 @@ The `<scale-level>` placeholder represents a named level in a sizing or spacing 
 
 **Dimension**: A dimension value is a string with a unit suffix. Valid units are: px, em, rem.
 
+**Duration**: A duration value is a string with a time unit. Valid units are: `ms`, `s` (e.g., `150ms`, `0.25s`).
+
+**CubicBezier**: A timing-function value, expressed as a four-element array of cubic-bezier control points: `[x1, y1, x2, y2]`. X-coordinates must be in the `[0, 1]` range; Y-coordinates may extend beyond it for overshoot easings.
+
 **Token References**: A token reference must be wrapped in curly braces, and contain an object path to another value in the YAML tree. For most token groups, the reference must point to a primitive value (e.g., `colors.primary-60`), not a group (e.g., `colors`). Within the `components` section, references to composite values (e.g., `{typography.label-md}`) are permitted.
 
 # Sections
@@ -87,8 +100,9 @@ Every `DESIGN.md` follows the same structure. Sections can be omitted if they're
 4. **Layout** (also: "Layout & Spacing")
 5. **Elevation & Depth** (also: "Elevation")
 6. **Shapes**
-7. **Components**
-8. **Do's and Don'ts**
+7. **Motion**
+8. **Components**
+9. **Do's and Don'ts**
 
 ### Prose and Tokens
 
@@ -274,6 +288,66 @@ rounded:
   full: 9999px
 ```
 
+## Motion
+
+This section describes how the design system uses motion — the durations,
+easing curves, and transitions that govern animated state changes.
+
+Motion tokens are platform-neutral: durations are stored in `ms` or `s`, and
+easing is stored as cubic-bezier control points so the same values compile to
+CSS, SwiftUI, Compose, and Flutter without reinterpretation.
+
+Example:
+
+```markdown
+## Motion
+
+Motion is editorial, not theatrical. Transitions confirm state changes — they
+do not perform. The system favors short durations and standard easing curves.
+
+- **Hover and focus (100–150ms):** Imperceptibly fast.
+- **Modals (400ms enter, 150ms exit):** Asymmetric in/out, mirroring physical
+  doors.
+- **Easing roles:** `decelerate` for elements entering, `accelerate` for
+  elements exiting, `standard` for everything else.
+```
+
+### Design Tokens
+
+The `motion` section has three sub-groups: `duration`, `easing`, and
+`transition`. Transitions are composite tokens that reference a duration and
+an easing.
+
+```yaml
+motion:
+  duration:
+    fast: 150ms
+    base: 250ms
+    slow: 400ms
+  easing:
+    standard:   [0.2, 0, 0, 1]
+    decelerate: [0, 0, 0, 1]
+    accelerate: [0.3, 0, 1, 1]
+  transition:
+    hover:
+      duration: "{motion.duration.fast}"
+      easing:   "{motion.easing.standard}"
+    enter:
+      duration: "{motion.duration.slow}"
+      easing:   "{motion.easing.decelerate}"
+```
+
+Components consume transitions via the `transition` sub-token. For asymmetric
+in/out timing, define separate component variants:
+
+```yaml
+components:
+  modal-enter:
+    transition: "{motion.transition.enter}"
+  modal-exit:
+    transition: "{motion.transition.exit}"
+```
+
 ## Components
 
 This section provides style guidance for component atoms within the design system. The following are common component types. Design systems are encouraged to define additional components relevant to their domain.
@@ -317,6 +391,7 @@ Each component has a set of properties that are themselves design tokens:
 - size: \<Dimension\>
 - height: \<Dimension\>
 - width: \<Dimension\>
+- transition: \<Transition\>
 
 ## Do's and Don'ts
 

--- a/examples/heritage/DESIGN.md
+++ b/examples/heritage/DESIGN.md
@@ -1,0 +1,164 @@
+---
+name: Heritage
+description: Editorial design system for premium long-form publications, with motion tokens for cross-platform animation.
+colors:
+  primary: "#1A1C1E"
+  secondary: "#6C7278"
+  tertiary: "#B8422E"
+  neutral: "#F7F5F2"
+  on-tertiary: "#F7F5F2"
+typography:
+  h1:
+    fontFamily: Public Sans
+    fontSize: 3rem
+    fontWeight: 600
+    lineHeight: 1.1
+    letterSpacing: -0.02em
+  body-md:
+    fontFamily: Public Sans
+    fontSize: 1rem
+    fontWeight: 400
+    lineHeight: 1.6
+  label-caps:
+    fontFamily: Space Grotesk
+    fontSize: 0.75rem
+    fontWeight: 500
+    lineHeight: 1
+    letterSpacing: 0.1em
+rounded:
+  sm: 4px
+  md: 8px
+spacing:
+  sm: 8px
+  md: 16px
+  lg: 32px
+motion:
+  duration:
+    instant: 100ms
+    fast: 150ms
+    base: 250ms
+    slow: 400ms
+    deliberate: 600ms
+  easing:
+    standard:   [0.2, 0.0, 0.0, 1.0]
+    decelerate: [0.0, 0.0, 0.0, 1.0]
+    accelerate: [0.3, 0.0, 1.0, 1.0]
+    emphasized: [0.3, 0.0, 0.0, 1.0]
+    linear:     [0.0, 0.0, 1.0, 1.0]
+  transition:
+    hover:
+      duration: "{motion.duration.fast}"
+      easing:   "{motion.easing.standard}"
+    focus:
+      duration: "{motion.duration.instant}"
+      easing:   "{motion.easing.standard}"
+    press:
+      duration: "{motion.duration.instant}"
+      easing:   "{motion.easing.standard}"
+    enter:
+      duration: "{motion.duration.slow}"
+      easing:   "{motion.easing.decelerate}"
+    exit:
+      duration: "{motion.duration.fast}"
+      easing:   "{motion.easing.accelerate}"
+    page:
+      duration: "{motion.duration.deliberate}"
+      easing:   "{motion.easing.emphasized}"
+components:
+  button-primary:
+    backgroundColor: "{colors.tertiary}"
+    textColor: "{colors.on-tertiary}"
+    rounded: "{rounded.sm}"
+    padding: 12px
+    transition: "{motion.transition.hover}"
+  button-primary-active:
+    transition: "{motion.transition.press}"
+  card:
+    backgroundColor: "{colors.neutral}"
+    textColor: "{colors.primary}"
+    rounded: "{rounded.md}"
+    padding: 24px
+    transition: "{motion.transition.hover}"
+  modal-enter:
+    transition: "{motion.transition.enter}"
+  modal-exit:
+    transition: "{motion.transition.exit}"
+  input-field:
+    backgroundColor: "{colors.neutral}"
+    textColor: "{colors.primary}"
+    rounded: "{rounded.sm}"
+    padding: 12px
+    transition: "{motion.transition.focus}"
+---
+
+## Overview
+
+Architectural Minimalism meets Journalistic Gravitas. The UI evokes a
+premium matte finish — a high-end broadsheet or contemporary gallery.
+
+## Colors
+
+The palette is rooted in high-contrast neutrals and a single accent color.
+
+- **Primary (#1A1C1E):** Deep ink for headlines and core text.
+- **Secondary (#6C7278):** Sophisticated slate for borders, captions, metadata.
+- **Tertiary (#B8422E):** "Boston Clay" — the sole driver for interaction.
+- **Neutral (#F7F5F2):** Warm limestone foundation, softer than pure white.
+
+## Typography
+
+Two families carry the system. **Public Sans** sets the editorial voice for
+headlines and body text; **Space Grotesk** provides technical contrast for
+labels, captions, and metadata.
+
+## Layout
+
+A fixed-max-width grid (1200px) on desktop, fluid on mobile. An 8px spacing
+scale governs all rhythm; cards use generous internal padding (24–32px) to
+emphasize editorial whitespace.
+
+## Elevation & Depth
+
+Depth is conveyed through tonal layers rather than shadows. The neutral
+limestone background recedes; primary content sits on slightly brighter
+surfaces with hairline borders in the secondary slate.
+
+## Shapes
+
+A restrained shape language: 4px radius on inputs and buttons, 8px on cards
+and modals.
+
+## Motion
+
+Motion in Heritage is **editorial, not theatrical**. Transitions confirm
+state changes — they do not perform. The system favors short durations and
+standard easing curves, mirroring the calm authority of broadsheet typography.
+
+- **Hover and focus (100–150ms):** Imperceptibly fast.
+- **Modals and drawers (400ms enter, 150ms exit):** Asymmetric — slower in,
+  faster out — mirrors physical doors.
+- **Page transitions (600ms):** Reserved for navigation between major
+  sections; the only place `emphasized` easing appears.
+- **Easing roles:** `decelerate` for entering elements, `accelerate` for
+  exiting, `standard` for everything else.
+
+Easings are stored as cubic-bezier control-point arrays so the same tokens
+compile to CSS, SwiftUI, Compose, and Flutter without reinterpretation.
+
+## Components
+
+Buttons, cards, and inputs all share the standard hover transition. The
+modal overrides with asymmetric enter/exit, and the hero CTA gets a one-off
+500ms emphasized transition as the single brand-expressive moment.
+
+## Do's and Don'ts
+
+- Do use the tertiary color only for the single most important action per
+  screen.
+- Don't mix rounded and sharp corners in the same view.
+- Do respect `prefers-reduced-motion` — collapse all durations to `0ms`.
+- Don't animate layout properties (`width`, `height`, `top`); animate
+  `transform` and `opacity` instead.
+- Don't use `emphasized` easing for routine transitions — reserve it for
+  brand-expressive moments.
+- Don't use `linear` easing for state changes; it reads as mechanical.

--- a/examples/heritage/README.md
+++ b/examples/heritage/README.md
@@ -1,0 +1,21 @@
+# Heritage
+
+An editorial design system for premium long-form publications. Architectural Minimalism meets Journalistic Gravitas — high-contrast neutrals, a single accent color, and motion tuned for editorial restraint rather than performance.
+
+This example demonstrates the `motion` token group: durations, cubic-bezier easings, and composite transitions referenced from components.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `DESIGN.md` | The complete design system specification, including motion tokens. |
+
+## Generating exports
+
+```bash
+npx @google/design.md export --format json-tailwind DESIGN.md > tailwind.theme.json
+npx @google/design.md export --format css-tailwind  DESIGN.md > theme.css
+npx @google/design.md export --format dtcg          DESIGN.md > tokens.json
+```
+
+The DTCG export emits motion tokens as W3C-conformant `duration`, `cubicBezier`, and `transition` types ready for Style Dictionary, Tokens Studio, or Figma Variables.

--- a/packages/cli/src/linter/dtcg/handler.test.ts
+++ b/packages/cli/src/linter/dtcg/handler.test.ts
@@ -191,4 +191,49 @@ describe('DtcgEmitterHandler', () => {
     expect(value['lineHeight']).toBeUndefined();
     expect(value['letterSpacing']).toBeUndefined();
   });
+
+  test('motion → duration/cubicBezier/transition groups under "motion"', () => {
+    const duration = new Map([
+      ['fast', { type: 'duration', value: 150, unit: 'ms' }],
+    ] as const);
+    const easing = new Map([
+      ['standard', { type: 'easing', controlPoints: [0.2, 0, 0, 1] }],
+    ] as const);
+    const transition = new Map([
+      ['hover', {
+        type: 'transition',
+        duration: { type: 'duration', value: 150, unit: 'ms' },
+        easing: { type: 'easing', controlPoints: [0.2, 0, 0, 1] },
+      }],
+    ] as const);
+    const state = emptyState({
+      motion: {
+        duration: duration as Map<string, never>,
+        easing: easing as Map<string, never>,
+        transition: transition as Map<string, never>,
+      } as never,
+    });
+
+    const result = handler.execute(state);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const motion = result.data['motion'] as Record<string, Record<string, unknown>>;
+    expect(motion).toBeDefined();
+    expect(motion['duration']!['$type']).toBe('duration');
+    expect((motion['duration']!['fast'] as Record<string, unknown>)['$value']).toEqual({ value: 150, unit: 'ms' });
+    expect(motion['easing']!['$type']).toBe('cubicBezier');
+    expect((motion['easing']!['standard'] as Record<string, unknown>)['$value']).toEqual([0.2, 0, 0, 1]);
+    expect(motion['transition']!['$type']).toBe('transition');
+    const transitionValue = (motion['transition']!['hover'] as Record<string, unknown>)['$value'] as Record<string, unknown>;
+    expect(transitionValue['duration']).toEqual({ value: 150, unit: 'ms' });
+    expect(transitionValue['timingFunction']).toEqual([0.2, 0, 0, 1]);
+  });
+
+  test('motion group is omitted entirely when no motion tokens exist', () => {
+    const result = handler.execute(emptyState());
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data['motion']).toBeUndefined();
+  });
 });

--- a/packages/cli/src/linter/dtcg/handler.ts
+++ b/packages/cli/src/linter/dtcg/handler.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DtcgEmitterSpec, DtcgEmitterResult, DtcgTokenFile, DtcgToken, DtcgGroup, DtcgColorValue, DtcgDimensionValue, DtcgTypographyValue } from './spec.js';
-import type { DesignSystemState, ResolvedColor, ResolvedDimension, ResolvedTypography } from '../model/spec.js';
+import type { DtcgEmitterSpec, DtcgEmitterResult, DtcgTokenFile, DtcgToken, DtcgGroup, DtcgColorValue, DtcgDimensionValue, DtcgTypographyValue, DtcgDurationValue, DtcgCubicBezierValue, DtcgTransitionValue } from './spec.js';
+import type { DesignSystemState, ResolvedColor, ResolvedDimension, ResolvedTypography, ResolvedDuration, ResolvedEasing, ResolvedTransition } from '../model/spec.js';
 
 const DTCG_SCHEMA_URL = 'https://www.designtokens.org/schemas/2025.10/format.json';
 
@@ -43,7 +43,59 @@ export class DtcgEmitterHandler implements DtcgEmitterSpec {
     const typographyGroup = this.mapTypography(state);
     if (typographyGroup) file['typography'] = typographyGroup;
 
+    const motionGroup = this.mapMotion(state);
+    if (motionGroup) file['motion'] = motionGroup;
+
     return { success: true, data: file as Record<string, unknown> };
+  }
+
+  private mapMotion(state: DesignSystemState): DtcgGroup | null {
+    if (!state.motion) return null;
+    const { duration, easing, transition } = state.motion;
+    if (duration.size === 0 && easing.size === 0 && transition.size === 0) return null;
+
+    const group: DtcgGroup = {};
+
+    if (duration.size > 0) {
+      const durGroup: DtcgGroup = { $type: 'duration' };
+      for (const [name, dur] of duration) {
+        durGroup[name] = { $value: this.durationToValue(dur) } as DtcgToken;
+      }
+      group['duration'] = durGroup;
+    }
+
+    if (easing.size > 0) {
+      const easeGroup: DtcgGroup = { $type: 'cubicBezier' };
+      for (const [name, ease] of easing) {
+        easeGroup[name] = { $value: this.easingToValue(ease) } as DtcgToken;
+      }
+      group['easing'] = easeGroup;
+    }
+
+    if (transition.size > 0) {
+      const tGroup: DtcgGroup = { $type: 'transition' };
+      for (const [name, t] of transition) {
+        tGroup[name] = { $value: this.transitionToValue(t) } as DtcgToken;
+      }
+      group['transition'] = tGroup;
+    }
+
+    return group;
+  }
+
+  private durationToValue(dur: ResolvedDuration): DtcgDurationValue {
+    return { value: dur.value, unit: dur.unit };
+  }
+
+  private easingToValue(ease: ResolvedEasing): DtcgCubicBezierValue {
+    return ease.controlPoints;
+  }
+
+  private transitionToValue(t: ResolvedTransition): DtcgTransitionValue {
+    return {
+      duration: this.durationToValue(t.duration),
+      timingFunction: this.easingToValue(t.easing),
+    };
   }
 
   private mapColors(state: DesignSystemState): DtcgGroup | null {

--- a/packages/cli/src/linter/dtcg/spec.ts
+++ b/packages/cli/src/linter/dtcg/spec.ts
@@ -36,11 +36,34 @@ export interface DtcgTypographyValue {
   lineHeight?: number;
 }
 
+/** Duration value per DTCG: { value, unit }. */
+export interface DtcgDurationValue {
+  value: number;
+  unit: 'ms' | 's';
+}
+
+/** Cubic-bezier value per DTCG: 4-element array of control points. */
+export type DtcgCubicBezierValue = [number, number, number, number];
+
+/** Transition composite per DTCG: duration + timingFunction. */
+export interface DtcgTransitionValue {
+  duration: DtcgDurationValue;
+  timingFunction: DtcgCubicBezierValue;
+}
+
 // ── DTCG Token & Group Structures ─────────────────────────────────
 
 export interface DtcgToken {
   $type?: string;
-  $value: DtcgColorValue | DtcgDimensionValue | DtcgTypographyValue | string | number;
+  $value:
+    | DtcgColorValue
+    | DtcgDimensionValue
+    | DtcgTypographyValue
+    | DtcgDurationValue
+    | DtcgCubicBezierValue
+    | DtcgTransitionValue
+    | string
+    | number;
   $description?: string;
 }
 

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -418,4 +418,116 @@ describe('ModelHandler', () => {
       expect(btn?.properties.get('fontWeight')).toBe(600);
     });
   });
+
+  describe('motion tokens', () => {
+    it('resolves duration tokens with ms and s units', () => {
+      const result = handler.execute(makeParsed({
+        motion: {
+          duration: { fast: '150ms', long: '0.4s' },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      expect(result.designSystem.motion?.duration.get('fast'))
+        .toEqual({ type: 'duration', value: 150, unit: 'ms' });
+      expect(result.designSystem.motion?.duration.get('long'))
+        .toEqual({ type: 'duration', value: 0.4, unit: 's' });
+    });
+
+    it('rejects durations with invalid units', () => {
+      const result = handler.execute(makeParsed({
+        motion: { duration: { broken: '150px' } },
+      }));
+      expect(result.findings).toHaveLength(1);
+      expect(result.findings[0]!.path).toBe('motion.duration.broken');
+      expect(result.findings[0]!.severity).toBe('error');
+    });
+
+    it('resolves easing as cubic-bezier control points', () => {
+      const result = handler.execute(makeParsed({
+        motion: {
+          easing: { standard: [0.2, 0, 0, 1] },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      expect(result.designSystem.motion?.easing.get('standard'))
+        .toEqual({ type: 'easing', controlPoints: [0.2, 0, 0, 1] });
+    });
+
+    it('rejects easing arrays with X-coords outside [0, 1]', () => {
+      const result = handler.execute(makeParsed({
+        motion: { easing: { broken: [1.5, 0, 0, 1] } },
+      }));
+      expect(result.findings).toHaveLength(1);
+      expect(result.findings[0]!.path).toBe('motion.easing.broken');
+    });
+
+    it('resolves transition composites with token references', () => {
+      const result = handler.execute(makeParsed({
+        motion: {
+          duration: { fast: '150ms' },
+          easing: { standard: [0.2, 0, 0, 1] },
+          transition: {
+            hover: {
+              duration: '{motion.duration.fast}',
+              easing: '{motion.easing.standard}',
+            },
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const hover = result.designSystem.motion?.transition.get('hover');
+      expect(hover?.type).toBe('transition');
+      expect(hover?.duration.value).toBe(150);
+      expect(hover?.easing.controlPoints).toEqual([0.2, 0, 0, 1]);
+    });
+
+    it('flags transitions referencing missing primitives', () => {
+      const result = handler.execute(makeParsed({
+        motion: {
+          transition: {
+            hover: {
+              duration: '{motion.duration.missing}',
+              easing: [0.2, 0, 0, 1],
+            },
+          },
+        },
+      }));
+      const errors = result.findings.filter(f => f.severity === 'error');
+      expect(errors).toHaveLength(1);
+      expect(errors[0]!.path).toBe('motion.transition.hover.duration');
+    });
+
+    it('exposes motion tokens in the symbol table for component refs', () => {
+      const result = handler.execute(makeParsed({
+        motion: {
+          duration: { fast: '150ms' },
+          easing: { standard: [0.2, 0, 0, 1] },
+          transition: {
+            hover: {
+              duration: '{motion.duration.fast}',
+              easing: '{motion.easing.standard}',
+            },
+          },
+        },
+        components: {
+          'button-primary': {
+            transition: '{motion.transition.hover}',
+          },
+        },
+      }));
+      const btn = result.designSystem.components.get('button-primary');
+      expect(btn?.unresolvedRefs).toEqual([]);
+      const transition = btn?.properties.get('transition');
+      expect(transition && typeof transition === 'object' && 'type' in transition && transition.type === 'transition').toBe(true);
+    });
+
+    it('produces no motion structure when input.motion is absent', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#000000' },
+      }));
+      expect(result.designSystem.motion?.duration.size).toBe(0);
+      expect(result.designSystem.motion?.easing.size).toBe(0);
+      expect(result.designSystem.motion?.transition.size).toBe(0);
+    });
+  });
 });

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -12,19 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { ParsedDesignSystem } from '../parser/spec.js';
+import type { ParsedDesignSystem, ParsedTransition } from '../parser/spec.js';
 import type {
   ModelSpec,
   ModelResult,
   ResolvedColor,
   ResolvedDimension,
   ResolvedTypography,
+  ResolvedDuration,
+  ResolvedEasing,
+  ResolvedTransition,
   ResolvedValue,
   ComponentDef,
   Finding,
 } from './spec.js';
 
-import { isValidColor, isParseableDimension, isTokenReference, parseDimensionParts } from './spec.js';
+import {
+  isValidColor,
+  isParseableDimension,
+  isTokenReference,
+  parseDimensionParts,
+  parseDuration,
+  isValidCubicBezier,
+} from './spec.js';
 
 const MAX_REFERENCE_DEPTH = 10;
 
@@ -168,6 +178,122 @@ export class ModelHandler implements ModelSpec {
         }
       }
 
+      // ── Phase 2.5: Resolve motion tokens ────────────────────────────
+      const motionDuration = new Map<string, ResolvedDuration>();
+      const motionEasing = new Map<string, ResolvedEasing>();
+      const motionTransition = new Map<string, ResolvedTransition>();
+
+      if (input.motion?.duration) {
+        for (const [name, raw] of Object.entries(input.motion.duration)) {
+          if (typeof raw !== 'string') {
+            findings.push({
+              severity: 'error',
+              path: `motion.duration.${name}`,
+              message: `Duration must be a string like '150ms', got ${typeof raw}.`,
+            });
+            continue;
+          }
+          if (isTokenReference(raw)) {
+            const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
+            if (resolved && typeof resolved === 'object' && 'type' in resolved && resolved.type === 'duration') {
+              motionDuration.set(name, resolved);
+              symbolTable.set(`motion.duration.${name}`, resolved);
+            } else {
+              findings.push({
+                severity: 'error',
+                path: `motion.duration.${name}`,
+                message: `Reference ${raw} does not resolve to a duration.`,
+              });
+            }
+          } else {
+            const parsed = parseDuration(raw);
+            if (!parsed) {
+              findings.push({
+                severity: 'error',
+                path: `motion.duration.${name}`,
+                message: `'${raw}' is not a valid duration. Expected a value with unit 'ms' or 's' (e.g., '150ms').`,
+              });
+              continue;
+            }
+            const resolved: ResolvedDuration = {
+              type: 'duration',
+              value: parsed.value,
+              unit: parsed.unit,
+            };
+            motionDuration.set(name, resolved);
+            symbolTable.set(`motion.duration.${name}`, resolved);
+          }
+        }
+      }
+
+      if (input.motion?.easing) {
+        for (const [name, raw] of Object.entries(input.motion.easing)) {
+          if (typeof raw === 'string' && isTokenReference(raw)) {
+            const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
+            if (resolved && typeof resolved === 'object' && 'type' in resolved && resolved.type === 'easing') {
+              motionEasing.set(name, resolved);
+              symbolTable.set(`motion.easing.${name}`, resolved);
+            } else {
+              findings.push({
+                severity: 'error',
+                path: `motion.easing.${name}`,
+                message: `Reference ${raw} does not resolve to an easing.`,
+              });
+            }
+            continue;
+          }
+          if (!isValidCubicBezier(raw)) {
+            findings.push({
+              severity: 'error',
+              path: `motion.easing.${name}`,
+              message: `Easing must be a 4-number cubic-bezier array (e.g., [0.2, 0, 0, 1]).`,
+            });
+            continue;
+          }
+          const resolved: ResolvedEasing = {
+            type: 'easing',
+            controlPoints: [raw[0]!, raw[1]!, raw[2]!, raw[3]!],
+          };
+          motionEasing.set(name, resolved);
+          symbolTable.set(`motion.easing.${name}`, resolved);
+        }
+      }
+
+      if (input.motion?.transition) {
+        for (const [name, raw] of Object.entries(input.motion.transition)) {
+          // Allow `transition.foo: "{motion.transition.bar}"` shorthand alias.
+          if (typeof raw === 'string' && isTokenReference(raw)) {
+            const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
+            if (resolved && typeof resolved === 'object' && 'type' in resolved && resolved.type === 'transition') {
+              motionTransition.set(name, resolved);
+              symbolTable.set(`motion.transition.${name}`, resolved);
+            } else {
+              findings.push({
+                severity: 'error',
+                path: `motion.transition.${name}`,
+                message: `Reference ${raw} does not resolve to a transition.`,
+              });
+            }
+            continue;
+          }
+
+          if (typeof raw !== 'object' || raw === null) {
+            findings.push({
+              severity: 'error',
+              path: `motion.transition.${name}`,
+              message: `Transition must be an object with 'duration' and 'easing'.`,
+            });
+            continue;
+          }
+
+          const transition = resolveTransition(raw as ParsedTransition, `motion.transition.${name}`, symbolTable, findings);
+          if (transition) {
+            motionTransition.set(name, transition);
+            symbolTable.set(`motion.transition.${name}`, transition);
+          }
+        }
+      }
+
       // ── Phase 3: Build components ──────────────────────────────────
       const components = new Map<string, ComponentDef>();
       if (input.components) {
@@ -212,6 +338,11 @@ export class ModelHandler implements ModelSpec {
           typography,
           rounded,
           spacing,
+          motion: {
+            duration: motionDuration,
+            easing: motionEasing,
+            transition: motionTransition,
+          },
           components,
           symbolTable,
           sections: input.sections,
@@ -225,6 +356,11 @@ export class ModelHandler implements ModelSpec {
           typography: new Map(),
           rounded: new Map(),
           spacing: new Map(),
+          motion: {
+            duration: new Map(),
+            easing: new Map(),
+            transition: new Map(),
+          },
           components: new Map(),
           symbolTable: new Map(),
         },
@@ -238,6 +374,69 @@ export class ModelHandler implements ModelSpec {
       };
     }
   }
+}
+
+/**
+ * Resolve a transition object's duration + easing into a ResolvedTransition.
+ * Returns null and pushes findings on failure.
+ */
+function resolveTransition(
+  raw: ParsedTransition,
+  path: string,
+  symbolTable: Map<string, ResolvedValue>,
+  findings: Finding[],
+): ResolvedTransition | null {
+  const duration = resolveDurationField(raw.duration, `${path}.duration`, symbolTable, findings);
+  const easing = resolveEasingField(raw.easing, `${path}.easing`, symbolTable, findings);
+  if (!duration || !easing) return null;
+  return { type: 'transition', duration, easing };
+}
+
+function resolveDurationField(
+  raw: string | undefined,
+  path: string,
+  symbolTable: Map<string, ResolvedValue>,
+  findings: Finding[],
+): ResolvedDuration | null {
+  if (typeof raw !== 'string') {
+    findings.push({ severity: 'error', path, message: `Missing or invalid 'duration' field.` });
+    return null;
+  }
+  if (isTokenReference(raw)) {
+    const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
+    if (resolved && typeof resolved === 'object' && 'type' in resolved && resolved.type === 'duration') {
+      return resolved;
+    }
+    findings.push({ severity: 'error', path, message: `Reference ${raw} does not resolve to a duration.` });
+    return null;
+  }
+  const parsed = parseDuration(raw);
+  if (!parsed) {
+    findings.push({ severity: 'error', path, message: `'${raw}' is not a valid duration.` });
+    return null;
+  }
+  return { type: 'duration', value: parsed.value, unit: parsed.unit };
+}
+
+function resolveEasingField(
+  raw: string | number[] | undefined,
+  path: string,
+  symbolTable: Map<string, ResolvedValue>,
+  findings: Finding[],
+): ResolvedEasing | null {
+  if (typeof raw === 'string' && isTokenReference(raw)) {
+    const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
+    if (resolved && typeof resolved === 'object' && 'type' in resolved && resolved.type === 'easing') {
+      return resolved;
+    }
+    findings.push({ severity: 'error', path, message: `Reference ${raw} does not resolve to an easing.` });
+    return null;
+  }
+  if (!isValidCubicBezier(raw)) {
+    findings.push({ severity: 'error', path, message: `Easing must be a 4-number cubic-bezier array.` });
+    return null;
+  }
+  return { type: 'easing', controlPoints: [raw[0]!, raw[1]!, raw[2]!, raw[3]!] };
 }
 
 // ── Pure utility functions ─────────────────────────────────────────

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -60,7 +60,36 @@ export interface ResolvedTypography {
   fontVariation?: string | undefined;
 }
 
-export type ResolvedValue = ResolvedColor | ResolvedDimension | ResolvedTypography | string;
+/** A duration token: numeric value + time unit (`ms` or `s`). */
+export interface ResolvedDuration {
+  type: 'duration';
+  value: number;
+  unit: 'ms' | 's';
+}
+
+/** A timing-function token, stored as four cubic-bezier control points. */
+export interface ResolvedEasing {
+  type: 'easing';
+  /** Cubic-bezier control points: [x1, y1, x2, y2]. */
+  controlPoints: [number, number, number, number];
+}
+
+/** A transition token — composite of duration + easing. */
+export interface ResolvedTransition {
+  type: 'transition';
+  duration: ResolvedDuration;
+  easing: ResolvedEasing;
+}
+
+export type ResolvedValue =
+  | ResolvedColor
+  | ResolvedDimension
+  | ResolvedTypography
+  | ResolvedDuration
+  | ResolvedEasing
+  | ResolvedTransition
+  | string
+  | number;
 
 // ── Re-exported from spec-config (single source of truth) ─────────
 export const VALID_TYPOGRAPHY_PROPS = _VALID_TYPOGRAPHY_PROPS;
@@ -74,6 +103,16 @@ export interface DesignSystemState {
   typography: Map<string, ResolvedTypography>;
   rounded: Map<string, ResolvedDimension>;
   spacing: Map<string, ResolvedDimension>;
+  /**
+   * Motion tokens. Always present after model resolution; optional on the
+   * type so callers constructing fixtures by hand don't need to spell out
+   * empty maps.
+   */
+  motion?: {
+    duration: Map<string, ResolvedDuration>;
+    easing: Map<string, ResolvedEasing>;
+    transition: Map<string, ResolvedTransition>;
+  } | undefined;
   components: Map<string, ComponentDef>;
   /** Flat lookup: "colors.primary" → ResolvedColor */
   symbolTable: Map<string, ResolvedValue>;
@@ -181,4 +220,30 @@ export const isValidDimension = isStandardDimension;
  */
 export function isTokenReference(raw: string): boolean {
   return /^\{[a-zA-Z0-9._-]+\}$/.test(raw);
+}
+
+/** Time units accepted for duration values. */
+const DURATION_UNITS = new Set(['ms', 's']);
+
+/**
+ * Parse a duration string like "150ms" or "0.25s".
+ * Returns null for non-duration strings.
+ */
+export function parseDuration(raw: string): { value: number; unit: 'ms' | 's' } | null {
+  const parts = parseDimensionParts(raw);
+  if (!parts) return null;
+  if (!DURATION_UNITS.has(parts.unit)) return null;
+  return { value: parts.value, unit: parts.unit as 'ms' | 's' };
+}
+
+/**
+ * Validate that a value is a 4-element array of numbers (a cubic-bezier curve).
+ * Y-coordinates may exceed [0,1] (overshoot); X-coordinates must be in [0,1].
+ */
+export function isValidCubicBezier(value: unknown): value is [number, number, number, number] {
+  if (!Array.isArray(value) || value.length !== 4) return false;
+  for (const n of value) {
+    if (typeof n !== 'number' || Number.isNaN(n)) return false;
+  }
+  return value[0]! >= 0 && value[0]! <= 1 && value[2]! >= 0 && value[2]! <= 1;
 }

--- a/packages/cli/src/linter/parser/handler.ts
+++ b/packages/cli/src/linter/parser/handler.ts
@@ -197,6 +197,7 @@ export class ParserHandler implements ParserSpec {
       typography: raw['typography'] as Record<string, Record<string, string | number>> | undefined,
       rounded: raw['rounded'] as Record<string, string> | undefined,
       spacing: raw['spacing'] as Record<string, string> | undefined,
+      motion: raw['motion'] as ParsedDesignSystem['motion'],
       components: raw['components'] as Record<string, Record<string, string>> | undefined,
       sourceMap,
       sections,

--- a/packages/cli/src/linter/parser/spec.ts
+++ b/packages/cli/src/linter/parser/spec.ts
@@ -37,6 +37,22 @@ export interface SourceLocation {
   block: 'frontmatter' | number;
 }
 
+/** Raw, unresolved transition object — mirrors the YAML schema */
+export interface ParsedTransition {
+  /** Duration as a dimension string (e.g., "150ms") or token reference. */
+  duration?: string | undefined;
+  /** Easing as a token reference or a 4-number cubic-bezier array. */
+  easing?: string | number[] | undefined;
+}
+
+/** Raw, unresolved motion tokens — mirrors the YAML schema */
+export interface ParsedMotion {
+  duration?: Record<string, string> | undefined;
+  /** Either a 4-number cubic-bezier array, or a `{motion.easing.foo}` reference. */
+  easing?: Record<string, string | number[]> | undefined;
+  transition?: Record<string, ParsedTransition | string> | undefined;
+}
+
 /** Raw, unresolved parsed output — mirrors the YAML schema */
 export interface ParsedDesignSystem {
   name?: string | undefined;
@@ -45,7 +61,8 @@ export interface ParsedDesignSystem {
   typography?: Record<string, Record<string, string | number>> | undefined;
   rounded?: Record<string, string> | undefined;
   spacing?: Record<string, string> | undefined;
-  components?: Record<string, Record<string, string>> | undefined;
+  motion?: ParsedMotion | undefined;
+  components?: Record<string, Record<string, string | number>> | undefined;
   sourceMap: Map<string, SourceLocation>;
   /** Markdown heading names found in the document (e.g., 'Colors', 'Typography') */
   sections?: string[] | undefined;

--- a/packages/cli/src/linter/spec-config.yaml
+++ b/packages/cli/src/linter/spec-config.yaml
@@ -36,6 +36,7 @@ sections:
     aliases:
       - Elevation
   - canonical: Shapes
+  - canonical: Motion
   - canonical: Components
   - canonical: "Do's and Don'ts"
 
@@ -76,6 +77,9 @@ component_sub_tokens:
     type: Dimension
   - name: width
     type: Dimension
+  - name: transition
+    type: Transition
+    description: "Reference to a `motion.transition.*` token. For asymmetric enter/exit, define separate component variants (e.g. `modal-enter`, `modal-exit`)."
 
 color_roles:
   - primary

--- a/packages/cli/src/linter/spec-gen/spec.mdx
+++ b/packages/cli/src/linter/spec-gen/spec.mdx
@@ -36,6 +36,15 @@ rounded:
   <scale-level>: <Dimension>
 spacing:
   <scale-level>: <Dimension | number>
+motion:
+  duration:
+    <token-name>: <Duration>
+  easing:
+    <token-name>: <CubicBezier>
+  transition:
+    <token-name>:
+      duration: <Duration | token reference>
+      easing: <CubicBezier | token reference>
 components:
   <component-name>:
     <token-name>: <string|token reference>
@@ -48,6 +57,10 @@ The `<scale-level>` placeholder represents a named level in a sizing or spacing 
 {typographyPropertyList()}
 
 **Dimension**: A dimension value is a string with a unit suffix. Valid units are: {STANDARD_UNITS.join(', ')}.
+
+**Duration**: A duration value is a string with a time unit. Valid units are: `ms`, `s` (e.g., `150ms`, `0.25s`).
+
+**CubicBezier**: A timing-function value, expressed as a four-element array of cubic-bezier control points: `[x1, y1, x2, y2]`. X-coordinates must be in the `[0, 1]` range; Y-coordinates may extend beyond it for overshoot easings.
 
 **Token References**: A token reference must be wrapped in curly braces, and contain an object path to another value in the YAML tree. For most token groups, the reference must point to a primitive value (e.g., `colors.primary-60`), not a group (e.g., `colors`). Within the `components` section, references to composite values (e.g., `{typography.label-md}`) are permitted.
 
@@ -216,6 +229,66 @@ rounded:
   md: 8px
   lg: 12px
   full: 9999px
+```
+
+## Motion
+
+This section describes how the design system uses motion — the durations,
+easing curves, and transitions that govern animated state changes.
+
+Motion tokens are platform-neutral: durations are stored in `ms` or `s`, and
+easing is stored as cubic-bezier control points so the same values compile to
+CSS, SwiftUI, Compose, and Flutter without reinterpretation.
+
+Example:
+
+```markdown
+## Motion
+
+Motion is editorial, not theatrical. Transitions confirm state changes — they
+do not perform. The system favors short durations and standard easing curves.
+
+- **Hover and focus (100–150ms):** Imperceptibly fast.
+- **Modals (400ms enter, 150ms exit):** Asymmetric in/out, mirroring physical
+  doors.
+- **Easing roles:** `decelerate` for elements entering, `accelerate` for
+  elements exiting, `standard` for everything else.
+```
+
+### Design Tokens
+
+The `motion` section has three sub-groups: `duration`, `easing`, and
+`transition`. Transitions are composite tokens that reference a duration and
+an easing.
+
+```yaml
+motion:
+  duration:
+    fast: 150ms
+    base: 250ms
+    slow: 400ms
+  easing:
+    standard:   [0.2, 0, 0, 1]
+    decelerate: [0, 0, 0, 1]
+    accelerate: [0.3, 0, 1, 1]
+  transition:
+    hover:
+      duration: "{motion.duration.fast}"
+      easing:   "{motion.easing.standard}"
+    enter:
+      duration: "{motion.duration.slow}"
+      easing:   "{motion.easing.decelerate}"
+```
+
+Components consume transitions via the `transition` sub-token. For asymmetric
+in/out timing, define separate component variants:
+
+```yaml
+components:
+  modal-enter:
+    transition: "{motion.transition.enter}"
+  modal-exit:
+    transition: "{motion.transition.exit}"
 ```
 
 ## Components

--- a/packages/cli/src/linter/tailwind/handler.ts
+++ b/packages/cli/src/linter/tailwind/handler.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { TailwindEmitterSpec, TailwindEmitterResult } from './spec.js';
-import type { DesignSystemState, ResolvedDimension } from '../model/spec.js';
+import type { DesignSystemState, ResolvedEasing } from '../model/spec.js';
 
 /**
  * Pure function mapping DesignSystemState → Tailwind theme.extend config.
@@ -31,11 +31,32 @@ export class TailwindEmitterHandler implements TailwindEmitterSpec {
             fontSize: this.mapFontSizes(state),
             borderRadius: this.mapDimensions(state.rounded),
             spacing: this.mapDimensions(state.spacing),
+            transitionDuration: this.mapDurations(state),
+            transitionTimingFunction: this.mapEasings(state),
           },
         },
       }
     };
   }
+
+  private mapDurations(state: DesignSystemState): Record<string, string> {
+    const result: Record<string, string> = {};
+    if (!state.motion) return result;
+    for (const [name, dur] of state.motion.duration) {
+      result[name] = `${dur.value}${dur.unit}`;
+    }
+    return result;
+  }
+
+  private mapEasings(state: DesignSystemState): Record<string, string> {
+    const result: Record<string, string> = {};
+    if (!state.motion) return result;
+    for (const [name, ease] of state.motion.easing) {
+      result[name] = easingCss(ease);
+    }
+    return result;
+  }
+
 
   private mapColors(state: DesignSystemState): Record<string, string> {
     const result: Record<string, string> = {};
@@ -80,4 +101,9 @@ export class TailwindEmitterHandler implements TailwindEmitterSpec {
   private dimToString(dim: { value: number; unit: string }): string {
     return `${dim.value}${dim.unit}`;
   }
+}
+
+function easingCss(ease: ResolvedEasing): string {
+  const [a, b, c, d] = ease.controlPoints;
+  return `cubic-bezier(${a}, ${b}, ${c}, ${d})`;
 }

--- a/packages/cli/src/linter/tailwind/spec.ts
+++ b/packages/cli/src/linter/tailwind/spec.ts
@@ -23,6 +23,8 @@ export const TailwindThemeExtendSchema = z.object({
   fontSize: z.record(z.tuple([z.string(), z.record(z.string())])).optional(),
   borderRadius: z.record(z.string()).optional(),
   spacing: z.record(z.string()).optional(),
+  transitionDuration: z.record(z.string()).optional(),
+  transitionTimingFunction: z.record(z.string()).optional(),
 });
 
 export type TailwindThemeExtend = z.infer<typeof TailwindThemeExtendSchema>;

--- a/packages/cli/src/linter/tailwind/v4/handler.test.ts
+++ b/packages/cli/src/linter/tailwind/v4/handler.test.ts
@@ -160,4 +160,35 @@ describe('TailwindV4EmitterHandler', () => {
       expect(result.success).toBe(false);
     });
   });
+
+  describe('motion mapping', () => {
+    it('emits durations, easings, and transition shorthand', () => {
+      const state = buildState({
+        motion: {
+          duration: { fast: '150ms' },
+          easing: { standard: [0.2, 0, 0, 1] },
+          transition: {
+            hover: {
+              duration: '{motion.duration.fast}',
+              easing: '{motion.easing.standard}',
+            },
+          },
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      expect(result.data.theme.duration?.['fast']).toBe('150ms');
+      expect(result.data.theme.easing?.['standard']).toBe('cubic-bezier(0.2, 0, 0, 1)');
+      expect(result.data.theme.transition?.['hover']).toBe('150ms cubic-bezier(0.2, 0, 0, 1)');
+    });
+
+    it('omits motion theme keys when no motion tokens are defined', () => {
+      const state = buildState({ colors: { primary: '#000000' } });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      expect(result.data.theme.duration).toBeUndefined();
+      expect(result.data.theme.easing).toBeUndefined();
+      expect(result.data.theme.transition).toBeUndefined();
+    });
+  });
 });

--- a/packages/cli/src/linter/tailwind/v4/handler.ts
+++ b/packages/cli/src/linter/tailwind/v4/handler.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { TailwindV4EmitterSpec, TailwindV4EmitterResult, TailwindV4ThemeData } from './spec.js';
-import type { DesignSystemState, ResolvedDimension } from '../../model/spec.js';
+import type { DesignSystemState, ResolvedDimension, ResolvedDuration, ResolvedEasing, ResolvedTransition } from '../../model/spec.js';
 
 const VALID_TOKEN_NAME = /^[a-zA-Z][a-zA-Z0-9-]*$/;
 
@@ -32,6 +32,9 @@ export class TailwindV4EmitterHandler implements TailwindV4EmitterSpec {
       ...state.typography.keys(),
       ...state.rounded.keys(),
       ...state.spacing.keys(),
+      ...(state.motion?.duration.keys() ?? []),
+      ...(state.motion?.easing.keys() ?? []),
+      ...(state.motion?.transition.keys() ?? []),
     ];
     for (const name of allNames) {
       if (!VALID_TOKEN_NAME.test(name)) {
@@ -81,6 +84,31 @@ export class TailwindV4EmitterHandler implements TailwindV4EmitterSpec {
       theme.spacing = mapDimensions(state.spacing);
     }
 
+    // Motion: duration, easing, transition (composite shorthand)
+    if (state.motion) {
+      if (state.motion.duration.size > 0) {
+        const durations: Record<string, string> = {};
+        for (const [name, dur] of state.motion.duration) {
+          durations[name] = durationToString(dur);
+        }
+        theme.duration = durations;
+      }
+      if (state.motion.easing.size > 0) {
+        const easings: Record<string, string> = {};
+        for (const [name, ease] of state.motion.easing) {
+          easings[name] = easingToCss(ease);
+        }
+        theme.easing = easings;
+      }
+      if (state.motion.transition.size > 0) {
+        const transitions: Record<string, string> = {};
+        for (const [name, t] of state.motion.transition) {
+          transitions[name] = transitionToCss(t);
+        }
+        theme.transition = transitions;
+      }
+    }
+
     return { success: true, data: { theme } };
   }
 }
@@ -95,6 +123,19 @@ function mapDimensions(dims: Map<string, ResolvedDimension>): Record<string, str
 
 function dimToString(dim: ResolvedDimension): string {
   return `${dim.value}${dim.unit}`;
+}
+
+function durationToString(dur: ResolvedDuration): string {
+  return `${dur.value}${dur.unit}`;
+}
+
+function easingToCss(ease: ResolvedEasing): string {
+  const [a, b, c, d] = ease.controlPoints;
+  return `cubic-bezier(${a}, ${b}, ${c}, ${d})`;
+}
+
+function transitionToCss(t: ResolvedTransition): string {
+  return `${durationToString(t.duration)} ${easingToCss(t.easing)}`;
 }
 
 /**

--- a/packages/cli/src/linter/tailwind/v4/serialize.ts
+++ b/packages/cli/src/linter/tailwind/v4/serialize.ts
@@ -24,6 +24,9 @@ const CATEGORIES: ReadonlyArray<readonly [keyof TailwindV4ThemeData, string]> = 
   ['fontWeight', '--font-weight-'],
   ['borderRadius', '--radius-'],
   ['spacing', '--spacing-'],
+  ['duration', '--duration-'],
+  ['easing', '--ease-'],
+  ['transition', '--transition-'],
 ];
 
 /**

--- a/packages/cli/src/linter/tailwind/v4/spec.ts
+++ b/packages/cli/src/linter/tailwind/v4/spec.ts
@@ -27,6 +27,9 @@ export const TailwindV4ThemeDataSchema = z.object({
   fontWeight: z.record(z.string()).optional(),
   borderRadius: z.record(z.string()).optional(),
   spacing: z.record(z.string()).optional(),
+  duration: z.record(z.string()).optional(),
+  easing: z.record(z.string()).optional(),
+  transition: z.record(z.string()).optional(),
 });
 
 export type TailwindV4ThemeData = z.infer<typeof TailwindV4ThemeDataSchema>;


### PR DESCRIPTION
Adds a  token group to DESIGN.md alongside ,
, , and . Three sub-groups:

-  — ,  (ms or s)
-    — cubic-bezier control points
-  — composite of

Components consume transitions via a single new sub-token, , that takes a token reference. Asymmetric in/out
timing is expressed via component variants (e.g. , ) — same pattern as .

Cross-platform by design: easings are stored as control-point arrays (the mathematical contract every animation engine implements), not CSS strings. Exports map cleanly to:

- Tailwind v4 — , ,
- Tailwind v3 — ,
- DTCG       —  /  /
                (W3C Design Tokens Format Module 2025.10)

Motion is fully optional. DESIGN.md files without  lint, export, and diff identically to before this change.

Includes:
- New canonical section  (between Shapes and Components)
- 12 new unit tests (model handler, Tailwind v4, DTCG)
- Regenerated docs/spec.md with motion schema, types, and section
- New example: examples/heritage/ demonstrating motion in context