### PR TITLE
feat(spec): add 9 standard CSS component sub-tokens

### DIFF
--- a/packages/cli/src/linter/spec-config.yaml
+++ b/packages/cli/src/linter/spec-config.yaml
@@ -70,12 +70,42 @@ component_sub_tokens:
     type: Dimension
   - name: padding
     type: Dimension
+  - name: paddingLeft
+    type: Dimension
+    description: "CSS logical directional padding, e.g. for margin-note inset patterns."
   - name: size
     type: Dimension
   - name: height
     type: Dimension
   - name: width
     type: Dimension
+  - name: minHeight
+    type: Dimension
+    description: "Minimum height (commonly 44px for touch-target compliance)."
+  - name: minWidth
+    type: Dimension
+    description: "Minimum width (e.g. circular buttons, touch-target compliance)."
+  - name: fontFamily
+    type: string
+    description: "Font family override per component (e.g. serif for CTAs, sans for chips)."
+  - name: fontWeight
+    type: "number | string"
+    description: "Font weight override per component."
+  - name: fontStyle
+    type: string
+    description: "CSS font-style value (e.g. 'italic' for margin-note patterns)."
+  - name: borderColor
+    type: Color
+    description: "Border color for card, chip, and container edges."
+  - name: borderLeftColor
+    type: Color
+    description: "Directional border color (e.g. accent left-edge for margin-notes)."
+  - name: borderLeftWidth
+    type: Dimension
+    description: "Directional border width. Follows CSS box-model naming."
+  - name: elevation
+    type: string
+    description: "Shadow/elevation class (e.g. 'shadow-lg'). Use sparingly; most components reject digital shadows in favor of tonal layers."
 
 color_roles:
   - primary


### PR DESCRIPTION
## Summary

Extends the `component_sub_tokens` vocabulary from 8 to 17 entries to support real-world design systems that use standard CSS properties within component definitions.

## Problem

The current 8-token vocabulary (`backgroundColor`, `textColor`, `typography`, `rounded`, `padding`, `size`, `height`, `width`) is insufficient for production design systems. Real-world components need additional standard CSS properties:

| Missing Token | Real-World Usage |
|---|---|
| `minHeight` / `minWidth` | Touch-target compliance (44 px, 56 px buttons) |
| `fontFamily` / `fontWeight` / `fontStyle` | Per-component type overrides (serif CTAs, italic margin-notes) |
| `borderColor` | Card, chip, and container borders |
| `borderLeftColor` / `borderLeftWidth` | Directional border patterns (left-edge accent) |
| `paddingLeft` | Directional padding (margin-note inset) |
| `elevation` | Shadow classes (floating SOS/elevated buttons) |

Without these in the spec, every real design system that uses them gets a wall of "not a recognized component sub-token" warnings. This makes `lint` output noisy and obscures actual issues.

## Change

Adds 9 new entries to `component_sub_tokens` in `spec-config.yaml`, each with:
- A descriptive name matching CSS naming conventions
- An appropriate type (`Color`, `Dimension`, `string`, or `number | string`)
- An optional description with usage context

All additions follow existing spec patterns. Directional variants (`borderLeftColor`, `paddingLeft`) use standard CSS box-model naming.

## Testing

Existing tests should pass (no token removals, only additions). The change is backwards-compatible — existing valid DESIGN.md files continue to validate, and the new tokens are recognized.