### PR TITLE
docs: document Windows/PowerShell npx invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,19 @@ Or run directly (always resolves from the public npm registry):
 npx @google/design.md lint DESIGN.md
 ```
 
+On **Windows/PowerShell**, this direct form can produce no output (or open
+`DESIGN.md` in your Markdown editor) because the `.md` suffix in the `design.md`
+bin name collides with the Windows Markdown file association during command
+resolution. Run the dot-free `designmd` alias instead — point `npx` at the
+package with `-p`, then invoke `designmd`:
+
+```bash
+npx -p @google/design.md designmd lint DESIGN.md
+```
+
+The `designmd` shim resolves to the same entrypoint and works identically across
+all platforms.
+
 #### `npm error ENOVERSIONS` (“No versions available for @google/design.md”)
 
 The CLI is published as [`@google/design.md` on npm](https://www.npmjs.com/package/@google/design.md). `ENOVERSIONS` almost always means npm is not querying the public registry (custom `registry=` in `.npmrc`, a corporate mirror that has not synced this package, or a misconfigured `@google:registry` for the `@google` scope).


### PR DESCRIPTION
## Summary

Documents the working `npx` invocation for Windows/PowerShell users in the README installation section.

## Why this matters (#93)

Running `npx @google/design.md lint DESIGN.md` in PowerShell on Windows produces no output, and in some cases Windows opens the `DESIGN.md` file in a Markdown editor instead of running the CLI. The root cause is the `design.md` bin name: the `.md` suffix collides with the Windows Markdown file association during command resolution, so the token resolves to a file rather than the npm shim.

The package already ships a dot-free `designmd` bin alias pointing at the same entrypoint, and the README already documents it for the `package.json`-script case. The gap was the direct-`npx` case that #93 is specifically about.

## Changes

- README: added a Windows/PowerShell note right after the direct-`npx` install example, pointing users at `npx -p @google/design.md designmd lint DESIGN.md` and briefly explaining the `.md` file-association collision. Wording is kept consistent with the existing `designmd`-alias guidance for the scripts case.

Docs-only; no code touched.

## Testing

- Verified against `packages/cli/package.json`: the `bin` map exposes both `design.md` and `designmd`, both pointing at `./dist/index.js`, so the documented `designmd` alias is accurate and resolves to the same entrypoint.
- Confirmed the macOS/Linux `npx @google/design.md lint DESIGN.md` instructions are unchanged.
- Markdown code fences are balanced and the new note is consistent with the pre-existing `designmd`-alias tip.

Fixes #93.
