### PR TITLE
feat: warn on token-like frontmatter keys silently ignored by export

### DIFF
--- a/packages/cli/src/commands/spec.test.ts
+++ b/packages/cli/src/commands/spec.test.ts
@@ -89,6 +89,6 @@ describe('spec command', () => {
     const output = JSON.parse(outputStr);
     expect(output.spec).toBeDefined();
     expect(output.rules).toBeDefined();
-    expect(output.rules.length).toBe(9);
+    expect(output.rules.length).toBe(10);
   });
 });

--- a/packages/cli/src/linter/index.ts
+++ b/packages/cli/src/linter/index.ts
@@ -45,6 +45,7 @@ export {
   missingSections,
   missingTypography,
   unknownKey,
+  tokenLikeIgnored,
 } from './linter/rules/index.js';
 export { contrastRatio } from './model/handler.js';
 export { TailwindEmitterHandler } from './tailwind/handler.js';

--- a/packages/cli/src/linter/linter/rules/index.ts
+++ b/packages/cli/src/linter/linter/rules/index.ts
@@ -24,6 +24,7 @@ import { missingSectionsRule } from './missing-sections.js';
 import { sectionOrderRule } from './section-order.js';
 import { missingTypographyRule } from './missing-typography.js';
 import { unknownKeyRule } from './unknown-key.js';
+import { tokenLikeIgnoredRule } from './token-like-ignored.js';
 
 /** The default set of lint rule descriptors, in order. */
 export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
@@ -36,6 +37,7 @@ export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
   missingTypographyRule,
   sectionOrderRule,
   unknownKeyRule,
+  tokenLikeIgnoredRule,
 ];
 
 /** Converts a RuleDescriptor into a LintRule by injecting severity into findings. */
@@ -61,4 +63,5 @@ export { missingSections } from './missing-sections.js';
 export { missingTypography } from './missing-typography.js';
 export { unknownKey } from './unknown-key.js';
 export { sectionOrder } from './section-order.js';
+export { tokenLikeIgnored } from './token-like-ignored.js';
 export type { LintRule } from './types.js';

--- a/packages/cli/src/linter/linter/rules/token-like-ignored.test.ts
+++ b/packages/cli/src/linter/linter/rules/token-like-ignored.test.ts
@@ -1,0 +1,133 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { tokenLikeIgnored } from './token-like-ignored.js';
+import { buildState } from './test-helpers.js';
+import type { SourceLocation } from '../../parser/spec.js';
+
+const loc: SourceLocation = { line: 1, column: 0, block: 'frontmatter' };
+
+describe('tokenLikeIgnored', () => {
+  it('warns when an unknown key has hex color leaf values', () => {
+    const state = buildState({
+      sourceMap: new Map([['base_colors', loc]]),
+      rawValues: { base_colors: { ink: '#0B0F14', mist: '#F5F7FA' } },
+    });
+    const findings = tokenLikeIgnored(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('base_colors');
+    expect(findings[0]!.message).toContain('"base_colors"');
+    expect(findings[0]!.message).toContain('silently ignored by export');
+  });
+
+  it('warns when an unknown key has a fontFamily property', () => {
+    const state = buildState({
+      sourceMap: new Map([['brand_type', loc]]),
+      rawValues: {
+        brand_type: { heading: { fontFamily: 'Inter', fontSize: '32px' } },
+      },
+    });
+    const findings = tokenLikeIgnored(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('brand_type');
+  });
+
+  it('warns when an unknown key has CSS dimension leaf values', () => {
+    const state = buildState({
+      sourceMap: new Map([['semantic_spacing', loc]]),
+      rawValues: { semantic_spacing: { sm: '4px', md: '8px', lg: '16px' } },
+    });
+    const findings = tokenLikeIgnored(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('semantic_spacing');
+  });
+
+  it('stays silent when an unknown key has a flat string value (not a map)', () => {
+    const state = buildState({
+      sourceMap: new Map([['theme', loc]]),
+      rawValues: { theme: 'dark' },
+    });
+    expect(tokenLikeIgnored(state)).toEqual([]);
+  });
+
+  it('stays silent when an unknown key has a number value', () => {
+    const state = buildState({
+      sourceMap: new Map([['version_major', loc]]),
+      rawValues: { version_major: 2 },
+    });
+    expect(tokenLikeIgnored(state)).toEqual([]);
+  });
+
+  it('stays silent when an unknown key has a non-token-like object (no hex, no dimension, no typo prop)', () => {
+    const state = buildState({
+      sourceMap: new Map([['meta', loc]]),
+      rawValues: { meta: { author: 'Jane', created: '2026-01-01' } },
+    });
+    expect(tokenLikeIgnored(state)).toEqual([]);
+  });
+
+  it('stays silent for all recognized schema keys', () => {
+    const state = buildState({
+      sourceMap: new Map([
+        ['version', loc],
+        ['name', loc],
+        ['colors', loc],
+        ['typography', loc],
+        ['spacing', loc],
+        ['rounded', loc],
+        ['components', loc],
+      ]),
+    });
+    expect(tokenLikeIgnored(state)).toEqual([]);
+  });
+
+  it('emits one finding per token-like unknown key', () => {
+    const state = buildState({
+      sourceMap: new Map([
+        ['base_colors', loc],
+        ['semantic_colors', loc],
+        ['meta', loc],
+      ]),
+      rawValues: {
+        base_colors: { primary: '#1A73E8' },
+        semantic_colors: { success: '#34A853' },
+        meta: { owner: 'design-team' },
+      },
+    });
+    const findings = tokenLikeIgnored(state);
+    expect(findings.length).toBe(2);
+    expect(findings.map(f => f.path).sort()).toEqual(['base_colors', 'semantic_colors']);
+  });
+
+  it('warns on nested token maps', () => {
+    const state = buildState({
+      sourceMap: new Map([['palette', loc]]),
+      rawValues: {
+        palette: {
+          light: { brand: '#4A90E2', surface: '#FFFFFF' },
+          dark: { brand: '#82B1FF', surface: '#121212' },
+        },
+      },
+    });
+    const findings = tokenLikeIgnored(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('palette');
+  });
+
+  it('returns empty when there are no unknown keys', () => {
+    const state = buildState({});
+    expect(tokenLikeIgnored(state)).toEqual([]);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/token-like-ignored.ts
+++ b/packages/cli/src/linter/linter/rules/token-like-ignored.ts
@@ -1,0 +1,100 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * CSS hex color pattern: #RGB, #RGBA, #RRGGBB, or #RRGGBBAA.
+ */
+const HEX_COLOR_RE = /^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+/**
+ * CSS dimension pattern: an optional sign, digits, and a CSS unit suffix.
+ */
+const CSS_DIMENSION_RE = /^-?\d*\.?\d+[a-zA-Z%]+$/;
+
+/**
+ * Typography-flavored property names that strongly suggest this map holds
+ * design tokens rather than arbitrary metadata.
+ */
+const TYPOGRAPHY_PROPS = new Set(['fontFamily', 'fontSize', 'fontWeight', 'lineHeight', 'letterSpacing']);
+
+/**
+ * Determine whether a plain object looks like a design-token map.
+ *
+ * A map is "token-like" when at least one leaf value is a hex color string or
+ * a CSS dimension string, OR at least one key is a well-known typography
+ * property name. Flat scalars (strings, numbers) and non-object values are
+ * never token-like on their own — the value must be an object.
+ */
+function isTokenLikeMap(value: unknown): boolean {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const obj = value as Record<string, unknown>;
+  return hasTokenLikeContent(obj);
+}
+
+function hasTokenLikeContent(obj: Record<string, unknown>): boolean {
+  for (const [key, val] of Object.entries(obj)) {
+    // Typography property key is itself a signal.
+    if (TYPOGRAPHY_PROPS.has(key)) return true;
+
+    if (typeof val === 'string') {
+      if (HEX_COLOR_RE.test(val) || CSS_DIMENSION_RE.test(val)) return true;
+    } else if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
+      // Recurse one level for nested token maps (e.g. base_colors: { light: { ink: "#0B0F14" } })
+      if (hasTokenLikeContent(val as Record<string, unknown>)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Token-like ignored keys — warns when a top-level YAML key is not part of
+ * the recognized export schema and its value looks like a design-token map.
+ * These values will be silently dropped by `design.md export`.
+ */
+export function tokenLikeIgnored(state: DesignSystemState): RuleFinding[] {
+  const unknownKeys = state.unknownKeys ?? [];
+  const unknownKeyValues = state.unknownKeyValues ?? {};
+  const findings: RuleFinding[] = [];
+
+  for (const key of unknownKeys) {
+    const value = unknownKeyValues[key];
+    if (isTokenLikeMap(value)) {
+      findings.push({
+        path: key,
+        message:
+          `"${key}" looks like a design-token map but is not a recognized schema key ` +
+          `(colors, typography, spacing, rounded, components). ` +
+          `It will be silently ignored by export commands. ` +
+          `Rename it to a supported key or move its values under a recognized section.`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+export const tokenLikeIgnoredRule: RuleDescriptor = {
+  name: 'token-like-ignored',
+  severity: 'warning',
+  description:
+    'Warns when a top-level YAML key looks like a design-token map but is not ' +
+    'part of the recognized export schema and will be silently ignored.',
+  run: tokenLikeIgnored,
+};

--- a/packages/cli/src/linter/linter/rules/types.test.ts
+++ b/packages/cli/src/linter/linter/rules/types.test.ts
@@ -40,7 +40,7 @@ describe('LintRule type', () => {
   });
 
   it('has all rules in DEFAULT_RULE_DESCRIPTORS', () => {
-    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(9);
+    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(10);
     DEFAULT_RULE_DESCRIPTORS.forEach((rule: RuleDescriptor) => {
       expect(rule.name).toBeTruthy();
       expect(rule.severity).toBeTruthy();

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -216,6 +216,15 @@ export class ModelHandler implements ModelSpec {
         key => !SCHEMA_KEY_SET.has(key)
       );
 
+      const unknownKeyValues: Record<string, unknown> = {};
+      if (input.rawValues) {
+        for (const key of unknownKeys) {
+          if (Object.prototype.hasOwnProperty.call(input.rawValues, key)) {
+            unknownKeyValues[key] = input.rawValues[key];
+          }
+        }
+      }
+
       return {
         designSystem: {
           name: input.name,
@@ -228,6 +237,7 @@ export class ModelHandler implements ModelSpec {
           symbolTable,
           sections: input.sections,
           unknownKeys,
+          unknownKeyValues,
         },
         findings,
       };

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -82,6 +82,8 @@ export interface DesignSystemState {
   sections?: string[] | undefined;
   /** Top-level YAML keys that are not part of the known schema */
   unknownKeys?: string[] | undefined;
+  /** Raw YAML values for unknown top-level keys, keyed by the unknown key name */
+  unknownKeyValues?: Record<string, unknown> | undefined;
 }
 
 export interface ComponentDef {

--- a/packages/cli/src/linter/parser/handler.ts
+++ b/packages/cli/src/linter/parser/handler.ts
@@ -202,6 +202,7 @@ export class ParserHandler implements ParserSpec {
       sourceMap,
       sections,
       documentSections,
+      rawValues: raw,
     };
   }
 

--- a/packages/cli/src/linter/parser/spec.ts
+++ b/packages/cli/src/linter/parser/spec.ts
@@ -52,6 +52,8 @@ export interface ParsedDesignSystem {
   sections?: string[] | undefined;
   /** Full content of each section, including heading and body. */
   documentSections?: Array<{ heading: string; content: string }> | undefined;
+  /** Raw YAML values for all top-level keys (known and unknown), used by lint rules. */
+  rawValues?: Record<string, unknown> | undefined;
 }
 
 /** Canonical top-level YAML keys per the DESIGN.md schema. */


### PR DESCRIPTION
## Summary

Adds a new `token-like-ignored` lint rule that warns when a top-level frontmatter key looks like a design-token map but is not part of the recognized export schema. Currently, keys like `base_colors` or `semantic_spacing` pass lint silently and are then completely dropped by `design.md export`. This is especially confusing for LLM-generated DESIGN.md files, where lint success implies export completeness but does not guarantee it.

## Why this matters

Fixes #100. The reporter's full color palette was silently discarded because their LLM used `base_colors` instead of `colors`. A warning at lint time surfaces the problem before export swallows the data.

## Approach

The rule detects "token-like" maps by inspecting leaf values for hex color strings, CSS dimension strings, and typography property names (`fontFamily`, `fontSize`, etc.). A plain metadata object like `meta: { author: "Jane" }` stays silent; a map of hex colors or rem values triggers a warning pointing the author toward the correct schema key.

To make raw YAML values available at rule evaluation time, the parser now carries `rawValues` through to `ParsedDesignSystem`, and the model layer extracts `unknownKeyValues` for keys not in the schema. No changes to the export pipeline are needed. Ten unit tests cover the happy path, edge cases (flat scalars, non-token objects, nested maps), and multi-key scenarios.

Fixes #100
