### PR TITLE
chore: tidy package verification script

### DIFF
--- a/packages/cli/scripts/check-package.ts
+++ b/packages/cli/scripts/check-package.ts
@@ -16,7 +16,7 @@
 /**
  * Package verification script for @google/design.md
  *
- * Runs 17 checks across 4 phases to ensure the package is correctly
+ * Runs package checks across 4 phases to ensure the package is correctly
  * structured for npm publication. Exit code 0 = all pass, 1 = failures.
  *
  * Usage: bun run scripts/check-package.ts
@@ -25,7 +25,7 @@
 import { readFileSync, existsSync, mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { join, resolve } from 'path';
 import { execSync } from 'child_process';
-import { Glob, $ } from 'bun';
+import { Glob } from 'bun';
 import { tmpdir } from 'os';
 
 // ── Helpers ────────────────────────────────────────────────────────


### PR DESCRIPTION
Summary
- Tidy the package verification script by avoiding a stale hard-coded check count.
- Remove the unused Bun `$` import.

Why
- The script has gained checks over time, so the fixed “17 checks” wording can drift again.
- Dropping the unused import keeps the maintenance script easier to scan.

Validation
- `git diff --check`
- `node --check packages/cli/scripts/check-package.ts`

Note
- Full `bun run lint` / `bun run test` were not run locally because Bun is not installed in this cron environment.
