### PR TITLE
fix: bundle spec.md next to the CLI entry so the spec command works after build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
         npm install $GITHUB_WORKSPACE/packages/cli/google-design.md-*.tgz
         echo -e '---\ncolors:\n  primary: "#0000ff"\n---' > DESIGN.md
         npx design.md lint DESIGN.md
+        npx design.md spec > /dev/null
         node -e "import('@google/design.md/linter').then(m => console.log('OK:', Object.keys(m).length, 'exports'))"
 
   npm-registry-smoke-windows:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bun build src/index.ts src/linter/index.ts --outdir dist --target node && npx tsc --project tsconfig.build.json --emitDeclarationOnly --skipLibCheck && cp src/linter/spec-config.yaml dist/linter/ && cp src/linter/spec-config.yaml dist/ && cp ../../docs/spec.md dist/linter/",
+    "build": "bun build src/index.ts src/linter/index.ts --outdir dist --target node && npx tsc --project tsconfig.build.json --emitDeclarationOnly --skipLibCheck && cp src/linter/spec-config.yaml dist/linter/ && cp src/linter/spec-config.yaml dist/ && cp ../../docs/spec.md dist/linter/ && cp ../../docs/spec.md dist/",
     "dev": "bun run src/index.ts",
     "test": "bun test",
     "lint": "tsc --noEmit --skipLibCheck",


### PR DESCRIPTION
## Summary

`npx @google/design.md spec` (and `spec --rules` / `spec --format json` without `--rules-only`) fails in an installed/published package with:

```
ERROR Failed to load spec.md.
  Bundled path: .../packages/cli/dist/spec.md
  Dev path:     .../docs/spec.md
```

## Reproduction

```bash
cd packages/cli && bun run build
node dist/index.js spec        # throws "Failed to load spec.md"
```

Or from a packed tarball: `bun pm pack` (or `npm pack`), extract/install it elsewhere, and run `node dist/index.js spec`.

## Root cause

`bun build src/index.ts src/linter/index.ts --outdir dist` bundles the CLI into `dist/index.js`, so at runtime `getSpecContent()` (Strategy 1 in `spec-helpers.ts`) resolves `spec.md` next to the executing module — i.e. `dist/spec.md`. The build script copies `docs/spec.md` only to `dist/linter/`, so `dist/spec.md` is absent. Strategy 2 (the dev fallback) then resolves `../../../../../docs/spec.md`, which points outside an installed package, so the command throws.

`spec --rules-only` happened to keep working because that path doesn't read `spec.md`.

This mirrors `spec-config.yaml`, which the build already copies to **both** `dist/` and `dist/linter/` for exactly the same reason — `spec.md` was just missing the `dist/` copy.

## Fix

- Copy `docs/spec.md` to `dist/` as well as `dist/linter/` in the build script (one extra `cp`, consistent with the existing `spec-config.yaml` handling on the same line).
- Add `npx design.md spec` to the tarball smoke test so the bundled-`spec.md` resolution is exercised in CI. The existing Windows registry-smoke job only runs `spec --rules-only`, which skips spec loading, so this regression was not covered.

## Testing

- `bun test` (packages/cli): **282 pass, 1 skip, 0 fail**
- `bun run lint` (`tsc --noEmit`): clean
- `bun run build` then `node dist/index.js spec`, `spec --rules`, `spec --format json`: all exit `0` with full output
- Packed the tarball, extracted it, and ran `node package/dist/index.js spec` from the installed layout: exits `0` with the full spec (confirms `dist/spec.md` ships and resolves)
