### PR TITLE
docs: correct lint/diff output examples and rule count in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npx @google/design.md lint DESIGN.md
       "message": "textColor (#ffffff) on backgroundColor (#1A1C1E) has contrast ratio 15.42:1 — passes WCAG AA."
     }
   ],
-  "summary": { "errors": 0, "warnings": 1, "info": 1 }
+  "summary": { "errors": 0, "warnings": 1, "infos": 1 }
 }
 ```
 
@@ -80,7 +80,15 @@ npx @google/design.md diff DESIGN.md DESIGN-v2.md
 {
   "tokens": {
     "colors": { "added": ["accent"], "removed": [], "modified": ["tertiary"] },
-    "typography": { "added": [], "removed": [], "modified": [] }
+    "typography": { "added": [], "removed": [], "modified": [] },
+    "rounded": { "added": [], "removed": [], "modified": [] },
+    "spacing": { "added": [], "removed": [], "modified": [] },
+    "components": { "added": [], "removed": [], "modified": [] }
+  },
+  "findings": {
+    "before": { "errors": 0, "warnings": 1, "infos": 1 },
+    "after": { "errors": 0, "warnings": 1, "infos": 1 },
+    "delta": { "errors": 0, "warnings": 0 }
   },
   "regression": false
 }
@@ -306,7 +314,7 @@ npx @google/design.md spec --rules-only --format json
 
 ## Linting Rules
 
-The linter runs nine rules against a parsed DESIGN.md. Each rule produces findings at a fixed severity level.
+The linter runs ten rules against a parsed DESIGN.md. Each rule produces findings at a fixed severity level.
 
 | Rule | Severity | What it checks |
 |:-----|:---------|:---------------|
@@ -319,6 +327,7 @@ The linter runs nine rules against a parsed DESIGN.md. Each rule produces findin
 | `missing-typography` | warning | Colors are defined but no typography tokens exist — agents will use default fonts |
 | `section-order` | warning | Sections appear out of the canonical order defined by the spec |
 | `unknown-key` | warning | A top-level YAML key looks like a typo of a known schema key (e.g. `colours:` → `colors:`); custom extension keys stay silent |
+| `token-like-ignored` | warning | A top-level YAML key looks like a design-token map but is not a recognized schema key, so `export` will silently ignore it |
 
 ### Programmatic API
 


### PR DESCRIPTION
## Summary

Three README accuracy fixes so the documented output matches what the CLI emits:

1. **lint `summary` key** — the README shows `"info": 1`, but `lint` emits `"infos"`. An agent parsing `summary.info` per the docs reads `undefined`. Corrected to `infos`.
2. **`diff` output shape** — the documented example shows only `colors`/`typography` under `tokens` and omits the `findings` block entirely. The actual output (`commands/diff.ts`) emits all five token categories (`colors`, `typography`, `rounded`, `spacing`, `components`) plus `findings: { before, after, delta }` and `regression`. Updated the example to match.
3. **rule count** — the table lists nine rules but `DEFAULT_RULE_DESCRIPTORS` registers ten; `token-like-ignored` (added in #105) was missing. Added the row and updated "nine" → "ten".

## Testing

Docs-only. Verified the rule list/severity against `packages/cli/src/linter/linter/rules/index.ts` and `token-like-ignored.ts`, and the diff/lint shapes against `commands/diff.ts`, `commands/lint.ts`, and `utils.ts`.