### PR TITLE
perf: bound token-validation cost on adversarial input

### DIFF
--- a/packages/cli/src/linter/linter/rules/token-like-ignored.ts
+++ b/packages/cli/src/linter/linter/rules/token-like-ignored.ts
@@ -26,6 +26,14 @@ const HEX_COLOR_RE = /^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
 const CSS_DIMENSION_RE = /^-?\d*\.?\d+[a-zA-Z%]+$/;
 
 /**
+ * Upper bound on a token-like leaf value's length before pattern matching.
+ * A hex color or CSS dimension is short; longer strings cannot match either,
+ * so capping the length avoids pathological regex backtracking on oversized
+ * attacker-supplied values.
+ */
+const MAX_TOKEN_VALUE_LENGTH = 64;
+
+/**
  * Typography-flavored property names that strongly suggest this map holds
  * design tokens rather than arbitrary metadata.
  */
@@ -54,7 +62,7 @@ function hasTokenLikeContent(obj: Record<string, unknown>): boolean {
     if (TYPOGRAPHY_PROPS.has(key)) return true;
 
     if (typeof val === 'string') {
-      if (HEX_COLOR_RE.test(val) || CSS_DIMENSION_RE.test(val)) return true;
+      if (val.length <= MAX_TOKEN_VALUE_LENGTH && (HEX_COLOR_RE.test(val) || CSS_DIMENSION_RE.test(val))) return true;
     } else if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
       // Recurse one level for nested token maps (e.g. base_colors: { light: { ink: "#0B0F14" } })
       if (hasTokenLikeContent(val as Record<string, unknown>)) return true;

--- a/packages/cli/src/linter/linter/rules/unknown-key.test.ts
+++ b/packages/cli/src/linter/linter/rules/unknown-key.test.ts
@@ -111,4 +111,12 @@ describe('unknownKey', () => {
     const findings = unknownKey(state);
     expect(findings.map(f => f.path).sort()).toEqual(['colours', 'typografy']);
   });
+
+  it('stays silent (and cheap) for very long keys via the length short-circuit', () => {
+    const state = buildState({
+      sourceMap: new Map([['a'.repeat(50000), loc]]),
+    });
+    const findings = unknownKey(state);
+    expect(findings.length).toBe(0);
+  });
 });

--- a/packages/cli/src/linter/linter/rules/unknown-key.ts
+++ b/packages/cli/src/linter/linter/rules/unknown-key.ts
@@ -34,6 +34,11 @@ export function unknownKey(state: DesignSystemState): RuleFinding[] {
     let bestMatch: string | undefined;
     let bestDist = Infinity;
     for (const known of SCHEMA_KEYS) {
+      // Edit distance is at least the length difference, so a key whose length
+      // differs from a known key by more than the typo threshold can never be a
+      // typo — skip the O(n*m) distance computation for it. This keeps the rule
+      // cheap on long, attacker-supplied keys without changing any result.
+      if (Math.abs(key.length - known.length) > MAX_TYPO_DISTANCE) continue;
       const dist = levenshtein(key.toLowerCase(), known.toLowerCase());
       if (dist < bestDist) {
         bestDist = dist;

--- a/packages/cli/src/linter/model/color-parser.ts
+++ b/packages/cli/src/linter/model/color-parser.ts
@@ -56,11 +56,18 @@ const CSS_NAMED_COLORS: Record<string, string> = {
 };
 
 /**
+ * Maximum nesting depth for recursive color-mix() resolution. Guards against
+ * stack exhaustion from pathologically nested, attacker-supplied color values.
+ */
+const MAX_COLOR_MIX_DEPTH = 32;
+
+/**
  * Parse a CSS color string into its sRGB representation + WCAG relative luminance.
  * Returns null if the color is invalid.
  */
-export function parseCssColor(colorStr: string): ParsedColorResult | null {
+export function parseCssColor(colorStr: string, depth = 0): ParsedColorResult | null {
   if (typeof colorStr !== 'string') return null;
+  if (depth > MAX_COLOR_MIX_DEPTH) return null;
   const clean = colorStr.trim().toLowerCase();
   if (!clean) return null;
 
@@ -202,8 +209,8 @@ export function parseCssColor(colorStr: string): ParsedColorResult | null {
       const parsed2 = parseColorWithWeight(subArgs[2]!);
       if (!parsed1 || !parsed2) return null;
 
-      const c1 = parseCssColor(parsed1.colorStr);
-      const c2 = parseCssColor(parsed2.colorStr);
+      const c1 = parseCssColor(parsed1.colorStr, depth + 1);
+      const c2 = parseCssColor(parsed2.colorStr, depth + 1);
       if (!c1 || !c2) return null;
 
       // Normalize weights

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -665,4 +665,20 @@ describe('ModelHandler', () => {
       expect(result.designSystem.colors.has(path)).toBe(true);
     });
   });
+
+  describe('color-mix nesting depth limit', () => {
+    it('rejects pathologically nested color-mix as an invalid color without collapsing the model', () => {
+      let nested = 'red';
+      for (let i = 0; i < 50; i++) nested = `color-mix(in srgb, ${nested}, blue)`;
+      const result = handler.execute(makeParsed({
+        colors: { ok: '#ffffff', deep: nested },
+      }));
+      // The over-deep color resolves to "invalid" (a precise per-token error),
+      // not a thrown RangeError that collapses the whole model build.
+      expect(result.designSystem.colors.has('deep')).toBe(false);
+      expect(result.findings.some(f => f.path === 'colors.deep' && f.severity === 'error')).toBe(true);
+      // Other valid tokens are unaffected.
+      expect(result.designSystem.colors.get('ok')?.hex).toBe('#ffffff');
+    });
+  });
 });

--- a/packages/cli/src/linter/model/spec.test.ts
+++ b/packages/cli/src/linter/model/spec.test.ts
@@ -79,6 +79,15 @@ describe('parseDimensionParts', () => {
     expect(parseDimensionParts('auto')).toBeNull();
     expect(parseDimensionParts('inherit')).toBeNull();
   });
+
+  it('returns null for oversized values without pathological backtracking', () => {
+    // Length-capped: an absurdly long value is rejected immediately rather than
+    // triggering quadratic regex backtracking.
+    expect(parseDimensionParts('1'.repeat(100000))).toBeNull();
+    expect(parseDimensionParts('1'.repeat(100000) + 'px')).toBeNull();
+    // Legitimate dimensions well under the cap still parse.
+    expect(parseDimensionParts('999999.999999px')).toEqual({ value: 999999.999999, unit: 'px' });
+  });
 });
 
 describe('isTokenReference', () => {

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -142,12 +142,20 @@ const CSS_UNITS = new Set([
 ]);
 
 /**
+ * Upper bound on a dimension string's length. Real CSS dimensions are a handful
+ * of characters; capping the length keeps validation linear and prevents
+ * pathological regex backtracking on oversized, attacker-supplied values.
+ */
+const MAX_DIMENSION_LENGTH = 64;
+
+/**
  * Parse a dimension string into its numeric value and unit suffix.
  * Accepts an optional leading sign and optional decimal (`.5rem` is valid).
  * Returns null for non-dimension strings (bare numbers, keywords like `auto`).
  */
 export function parseDimensionParts(raw: string): { value: number; unit: string } | null {
   if (typeof raw !== 'string') return null;
+  if (raw.length > MAX_DIMENSION_LENGTH) return null;
   const match = raw.match(/^(-?\d*\.?\d+)([a-zA-Z%]+)$/);
   if (!match) return null;
   const value = parseFloat(match[1]!);


### PR DESCRIPTION
## Summary

The CLI parses arbitrary user-supplied markdown/YAML (file or stdin). Three validation paths can be driven into super-linear CPU or unbounded recursion by a crafted DESIGN.md. Each fix is a small guard that leaves results for legitimate input unchanged.

### 1. Quadratic backtracking in dimension validation
`parseDimensionParts` (`model/spec.ts`) uses `/^(-?\d*\.?\d+)([a-zA-Z%]+)$/`; the same shape is in `token-like-ignored`'s `CSS_DIMENSION_RE`. On a long all-digit string the engine backtracks every split point (clean O(n²) — measurable seconds at ~80k chars). Real CSS dimensions are a handful of characters, so a leaf value over 64 chars is rejected before the regex runs.

### 2. Unbounded Levenshtein cost for unknown keys
`unknown-key` builds a full `(m+1)×(n+1)` DP matrix against every schema key for each unknown top-level key, with no length guard. Since edit distance is always ≥ the length difference, a key whose length differs from a schema key by more than `MAX_TYPO_DISTANCE` can never be a typo — those comparisons are now skipped. Suggestions are provably unchanged.

### 3. Unbounded `color-mix()` recursion
`parseCssColor` recurses into each inner color of a `color-mix()` with no depth bound; a deeply nested value throws `RangeError: Maximum call stack size exceeded`, which the model's catch-all turns into a single generic error that discards every other finding for the file. A depth counter (cap 32) makes an over-deep value resolve to a normal "invalid color" finding instead, leaving the rest of the model intact.

## Testing

- `bun test`: **285 pass, 1 skip, 0 fail** (added 3 tests). The suite completes in ~0.3s, including a 100k-char dimension, a 50k-char unknown key, and a 50-deep `color-mix` — all previously slow/throwing, now instant/graceful.
- `bun run lint` (`tsc --noEmit`): clean.
- The new color-mix test asserts the over-deep value is rejected per-token **and** that a sibling valid color still resolves (i.e. no model-wide collapse).