### PR TITLE
fix(export): escape line terminators in Tailwind v4 CSS string values

### DIFF
--- a/packages/cli/src/linter/tailwind/v4/handler.test.ts
+++ b/packages/cli/src/linter/tailwind/v4/handler.test.ts
@@ -99,6 +99,20 @@ describe('TailwindV4EmitterHandler', () => {
       if (!result.success) throw new Error('Expected success');
       expect(result.data.theme.fontFamily?.['fancy']).toBe('"Fancy \\"Font\\""');
     });
+
+    it('escapes line terminators in font-family values', () => {
+      const state = buildState({
+        typography: {
+          multi: { fontFamily: 'Evil\nFamily', fontSize: '16px' },
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      const value = result.data.theme.fontFamily?.['multi'];
+      // A raw newline must not survive into the emitted CSS string.
+      expect(value).not.toContain('\n');
+      expect(value).toBe('"Evil\\a Family"');
+    });
   });
 
   describe('dimensions mapping', () => {

--- a/packages/cli/src/linter/tailwind/v4/handler.ts
+++ b/packages/cli/src/linter/tailwind/v4/handler.ts
@@ -100,7 +100,13 @@ function dimToString(dim: ResolvedDimension): string {
 /**
  * Wrap a string value in double quotes, escaping embedded `\` and `"`.
  * Produces a CSS-safe string literal suitable for font-family values.
+ * Line terminators (newline, carriage return, form feed) are illegal raw inside
+ * a CSS string and could break the value out of the quoted token, so they are
+ * emitted as CSS hex escapes (e.g. `\a `).
  */
 function cssStringLiteral(value: string): string {
-  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  return `"${value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/[\n\r\f]/g, (c) => `\\${c.charCodeAt(0).toString(16)} `)}"`;
 }


### PR DESCRIPTION
## Summary

The Tailwind v4 exporter wraps font-family values with `cssStringLiteral`, which escaped only `\` and `"`. A value containing a raw newline / carriage return / form feed — valid via a YAML double-quoted or block scalar in a DESIGN.md — was emitted verbatim inside the `@theme` CSS string literal. Raw line terminators are illegal inside a CSS string and can break the value out of the quoted token, producing malformed CSS.

This complements the existing token-name validation (which already rejects non-identifier names): names are validated, and string *values* are now fully escaped.

## Fix

Escape `\n`, `\r`, and `\f` as CSS hex escapes (e.g. `\a `) in `cssStringLiteral`, alongside the existing `\`/`"` escaping.

## Testing

- `bun test`: **283 pass, 1 skip, 0 fail** (added a test: a font-family containing a newline emits `"Evil\a Family"` with no raw newline)
- `bun run lint` (`tsc --noEmit`): clean
- Existing quote/backslash escaping test unchanged and passing