### PR TITLE
chore: declare supported Node engine range (>=18)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,9 @@
   ],
   "private": false,
   "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "bin": {
     "design.md": "./dist/index.js",
     "designmd": "./dist/index.js"


### PR DESCRIPTION
## Summary

The published package has no `engines.node`, so consumers get no signal about the minimum supported Node version. The CLI/library uses modern Node features — ESM with `import.meta.url` + `fileURLToPath`, an `exports` map, and async iteration over `process.stdin` — so a floor is appropriate.

Declares `engines.node: ">=18.0.0"`. This is advisory by default (npm warns below it; it does not hard-block unless the consumer sets `engine-strict`), so it is non-breaking.

## Testing

Metadata only. `package.json` validated as parseable; `node`/`bun` resolution unaffected.