### PR TITLE
feat(lint): flag unrecognized typography sub-properties

### DIFF
--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -366,6 +366,20 @@ describe('ModelHandler', () => {
       const headline = result.designSystem.typography.get('headline');
       expect(headline?.fontWeight).toBe(700);
     });
+
+    it('warns about unrecognized typography sub-properties that are silently dropped', () => {
+      const result = handler.execute(makeParsed({
+        typography: {
+          'headline': { fontFamily: 'Inter', textTransform: 'uppercase' },
+        },
+      }));
+      const warning = result.findings.find(f => f.path === 'typography.headline.textTransform');
+      expect(warning).toBeDefined();
+      expect(warning?.severity).toBe('warning');
+      // The recognized property is still resolved, and known props never warn.
+      expect(result.designSystem.typography.get('headline')?.fontFamily).toBe('Inter');
+      expect(result.findings.some(f => f.path === 'typography.headline.fontFamily')).toBe(false);
+    });
   });
 
   describe('rounded validation', () => {

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -25,7 +25,7 @@ import type {
   Finding,
 } from './spec.js';
 
-import { isValidColor, isParseableDimension, isTokenReference, parseDimensionParts } from './spec.js';
+import { isValidColor, isParseableDimension, isTokenReference, parseDimensionParts, VALID_TYPOGRAPHY_PROPS } from './spec.js';
 import { parseCssColor } from './color-parser.js';
 
 import {
@@ -34,6 +34,7 @@ import {
 } from '../spec-config.js';
 
 const SCHEMA_KEY_SET: ReadonlySet<string> = new Set(SCHEMA_KEYS);
+const TYPOGRAPHY_PROP_SET: ReadonlySet<string> = new Set(VALID_TYPOGRAPHY_PROPS);
 
 /**
  * Builds a resolved DesignSystemState from parsed YAML tokens.
@@ -364,6 +365,19 @@ function parseTypography(props: Record<string, string | number>, path: string, f
           message: `'${raw}' is not a valid dimension.`,
         });
       }
+    }
+  }
+
+  // Surface typography sub-properties that aren't part of the schema: they are
+  // silently dropped (never resolved or emitted), so warn rather than ignore —
+  // mirroring how unknown component sub-tokens are reported.
+  for (const key of Object.keys(props)) {
+    if (!TYPOGRAPHY_PROP_SET.has(key)) {
+      findings.push({
+        severity: 'warning',
+        path: `${path}.${key}`,
+        message: `'${key}' is not a recognized typography property. Valid properties: ${VALID_TYPOGRAPHY_PROPS.join(', ')}.`,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

Typography sub-properties outside the schema — `fontFamily`, `fontSize`, `fontWeight`, `lineHeight`, `letterSpacing`, `fontFeature`, `fontVariation` — were silently dropped by the model: never resolved, never emitted to Tailwind/DTCG, and with **no finding**. A typo (`fontwight`) or an unsupported property (`textTransform`, `color`) simply vanished, looking identical to "the linter didn't notice."

This mirrors the existing treatment of unknown **component** sub-tokens, which the `broken-ref` rule already reports as a warning (*"'X' is not a recognized component sub-token"*).

## Change

`parseTypography` now emits a `warning` for each sub-property not in the schema, e.g.:

```
'textTransform' is not a recognized typography property. Valid properties: fontFamily, fontSize, fontWeight, lineHeight, letterSpacing, fontFeature, fontVariation.
```

Recognized properties resolve exactly as before. Warnings don't affect the exit code (only errors do), so this is additive.

## Testing

- `bun test`: **283 pass, 1 skip, 0 fail** (added a test: an unknown `textTransform` warns at `typography.<token>.textTransform` while `fontFamily` still resolves and never warns).
- `bun run lint` (`tsc --noEmit`): clean.
- Verified no existing fixture or test uses a non-standard typography property, so no current case newly warns.