### PR TITLE
fix(export): exit 0 on a successful export regardless of source lint findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ npx @google/design.md export --format dtcg DESIGN.md > tokens.json
 | `tailwind` | JSON | Alias for `json-tailwind` |
 | `dtcg` | JSON | W3C Design Tokens Format Module |
 
+Exit code `0` on a successful export (regardless of any lint findings in the source — run `lint` to gate on those), `1` on an invalid `--format` or an emitter error, and `2` if the input file cannot be read.
+
 ### `spec`
 
 Output the DESIGN.md format specification (useful for injecting spec context into agent prompts).

--- a/packages/cli/src/commands/export-exit-code.test.ts
+++ b/packages/cli/src/commands/export-exit-code.test.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, afterAll } from 'bun:test';
+import { join } from 'node:path';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+const CLI = join(import.meta.dir, '../index.ts');
+
+function run(args: string[]): { code: number | null; stdout: string } {
+  const proc = Bun.spawnSync(['bun', 'run', CLI, ...args], { stdout: 'pipe', stderr: 'pipe' });
+  return { code: proc.exitCode, stdout: Buffer.from(proc.stdout).toString('utf-8') };
+}
+
+describe('export exit code', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'designmd-export-'));
+  const badFile = join(dir, 'DESIGN.md');
+  // An invalid color is a lint *error*, but the export itself still succeeds.
+  writeFileSync(badFile, '---\ncolors:\n  primary: "notacolor"\n---\n## Colors\n');
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('exits 0 on a successful export even when the source has lint errors', () => {
+    const { code, stdout } = run(['export', '--format', 'json-tailwind', badFile]);
+    expect(code).toBe(0);
+    expect(stdout.trim().length).toBeGreaterThan(0);
+  });
+
+  it('lint still exits 1 on the same source (the validation gate)', () => {
+    const { code } = run(['lint', badFile]);
+    expect(code).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -87,6 +87,8 @@ export default defineCommand({
       console.log(JSON.stringify(result.data, null, 2));
     }
 
-    process.exitCode = report.summary.errors > 0 ? 1 : 0;
+    // A successful export exits 0 even if the source has lint findings; those
+    // are surfaced by `lint`, not by whether the export itself produced output.
+    // The error branches above set a non-zero code and return before this point.
   },
 });


### PR DESCRIPTION
## Summary

`export` set its exit code from the *source's* lint summary:

```js
process.exitCode = report.summary.errors > 0 ? 1 : 0;
```

So exporting a DESIGN.md that has a lint **error** (e.g. one invalid color) exited `1` even though the export ran and produced correct output for every valid token. That conflates two different things — "the source has lint findings" and "the export failed" — in one exit code, and it's undocumented.

## Change (behavior change)

Decouple the export exit code from source lint findings:

- **0** — export succeeded (even if the source has lint findings; use `lint` to gate on those)
- **1** — invalid `--format` or an emitter failure
- **2** — input file could not be read (`readInput`)

Documented in the README's `export` section. This is a deliberate behavior change on the success path (export of a lint-error file: `1` → `0`); flagging it explicitly in case the coupling was intended as a validation gate — `lint` already serves that purpose.

## Testing

- New `commands/export-exit-code.test.ts` (spawns the CLI): export of a lint-error file → exit `0` with output; `lint` of the same file → exit `1`.
- `bun test`: **284 pass, 1 skip, 0 fail**. `bun run lint`: clean.
- Verified against the built CLI with both an error-containing and a valid source.