### PR TITLE
 fix: graceful ENOENT error when DESIGN.md is missing (#132)

### DIFF
--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -14,7 +14,7 @@
 
 import { defineCommand } from 'citty';
 import { lint } from '../linter/index.js';
-import { readInput, formatOutput, diffMaps } from '../utils.js';
+import { readInput, formatOutput, diffMaps, FileReadError } from '../utils.js';
 import type { ComponentDef } from '../linter/model/spec.js';
 
 export default defineCommand({
@@ -40,8 +40,18 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const beforeContent = await readInput(args.before);
-    const afterContent = await readInput(args.after);
+    let beforeContent: string, afterContent: string;
+    try {
+      beforeContent = await readInput(args.before);
+      afterContent = await readInput(args.after);
+    } catch (error) {
+      if (error instanceof FileReadError) {
+        process.stderr.write(`Error: "${error.filePath}" not found.\nCreate a DESIGN.md file or pass "-" to read from stdin.\n`);
+        process.exitCode = 2;
+        return;
+      }
+      throw error;
+    }
 
     const beforeReport = lint(beforeContent);
     const afterReport = lint(afterContent);

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -46,7 +46,7 @@ export default defineCommand({
       afterContent = await readInput(args.after);
     } catch (error) {
       if (error instanceof FileReadError) {
-        process.stderr.write(`Error: "${error.filePath}" not found.\nCreate a DESIGN.md file or pass "-" to read from stdin.\n`);
+        process.stderr.write(`Error: ${error.friendlyMessage}\n`);
         process.exitCode = 2;
         return;
       }

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -15,7 +15,7 @@
 import { defineCommand } from 'citty';
 import { lint, TailwindEmitterHandler, TailwindV4EmitterHandler, serializeTailwindV4 } from '../linter/index.js';
 import { DtcgEmitterHandler } from '../linter/dtcg/handler.js';
-import { readInput } from '../utils.js';
+import { readInput, FileReadError } from '../utils.js';
 
 const FORMATS = ['css-tailwind', 'json-tailwind', 'tailwind', 'dtcg'] as const;
 type ExportFormat = typeof FORMATS[number];
@@ -49,7 +49,17 @@ export default defineCommand({
       return;
     }
 
-    const content = await readInput(args.file);
+    let content: string;
+    try {
+      content = await readInput(args.file);
+    } catch (error) {
+      if (error instanceof FileReadError) {
+        process.stderr.write(`Error: "${error.filePath}" not found.\nCreate a DESIGN.md file or pass "-" to read from stdin.\n`);
+        process.exitCode = 2;
+        return;
+      }
+      throw error;
+    }
     const report = lint(content);
 
     if (format === 'css-tailwind') {

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -54,7 +54,7 @@ export default defineCommand({
       content = await readInput(args.file);
     } catch (error) {
       if (error instanceof FileReadError) {
-        process.stderr.write(`Error: "${error.filePath}" not found.\nCreate a DESIGN.md file or pass "-" to read from stdin.\n`);
+        process.stderr.write(`Error: ${error.friendlyMessage}\n`);
         process.exitCode = 2;
         return;
       }

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -14,7 +14,7 @@
 
 import { defineCommand } from 'citty';
 import { lint } from '../linter/index.js';
-import { readInput, formatOutput } from '../utils.js';
+import { readInput, formatOutput, FileReadError } from '../utils.js';
 
 export default defineCommand({
   meta: {
@@ -34,7 +34,17 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const content = await readInput(args.file);
+    let content: string;
+    try {
+      content = await readInput(args.file);
+    } catch (error) {
+      if (error instanceof FileReadError) {
+        process.stderr.write(`Error: "${error.filePath}" not found.\nCreate a DESIGN.md file or pass "-" to read from stdin.\n`);
+        process.exitCode = 2;
+        return;
+      }
+      throw error;
+    }
     const report = lint(content);
 
     const output = {

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -39,7 +39,7 @@ export default defineCommand({
       content = await readInput(args.file);
     } catch (error) {
       if (error instanceof FileReadError) {
-        process.stderr.write(`Error: "${error.filePath}" not found.\nCreate a DESIGN.md file or pass "-" to read from stdin.\n`);
+        process.stderr.write(`Error: ${error.friendlyMessage}\n`);
         process.exitCode = 2;
         return;
       }

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -13,7 +13,24 @@
 // limitations under the License.
 
 import { describe, it, expect } from 'bun:test';
-import { formatOutput } from './utils.js';
+import { readInput, FileReadError, formatOutput } from './utils.js';
+
+describe('readInput', () => {
+  it('throws FileReadError when file does not exist', async () => {
+    const err = await readInput('/nonexistent-path/DESIGN.md').catch(e => e);
+    expect(err).toBeInstanceOf(FileReadError);
+  });
+
+  it('FileReadError carries the missing file path', async () => {
+    const err = await readInput('/nonexistent-path/DESIGN.md').catch(e => e);
+    expect((err as FileReadError).filePath).toBe('/nonexistent-path/DESIGN.md');
+  });
+
+  it('FileReadError carries the underlying OS error message', async () => {
+    const err = await readInput('/nonexistent-path/DESIGN.md').catch(e => e);
+    expect((err as FileReadError).message).toContain('ENOENT');
+  });
+});
 
 describe('formatOutput', () => {
   describe('--format markdown', () => {

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -30,6 +30,24 @@ describe('readInput', () => {
     const err = await readInput('/nonexistent-path/DESIGN.md').catch(e => e);
     expect((err as FileReadError).message).toContain('ENOENT');
   });
+
+  it('friendlyMessage says "not found" for ENOENT', async () => {
+    const err = await readInput('/nonexistent-path/DESIGN.md').catch(e => e);
+    expect((err as FileReadError).friendlyMessage).toContain('not found');
+  });
+
+  it('friendlyMessage says "permission denied" for EACCES', () => {
+    const cause = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+    const err = new FileReadError('/some/file.md', cause);
+    expect(err.friendlyMessage).toContain('permission denied');
+    expect(err.friendlyMessage).not.toContain('not found');
+  });
+
+  it('friendlyMessage falls back to the raw message for unknown errors', () => {
+    const cause = Object.assign(new Error('ENOMEM: out of memory'), { code: 'ENOMEM' });
+    const err = new FileReadError('/some/file.md', cause);
+    expect(err.friendlyMessage).toContain('ENOMEM');
+  });
 });
 
 describe('formatOutput', () => {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -14,13 +14,20 @@
 
 import { readFileSync } from 'node:fs';
 
+export class FileReadError extends Error {
+  readonly code = 'FILE_READ_ERROR' as const;
+  constructor(public readonly filePath: string, cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+    this.name = 'FileReadError';
+  }
+}
+
 /**
  * Read input from a file path or stdin ("-").
- * Never throws — returns the content string or exits with error JSON.
+ * Throws FileReadError if the file cannot be read.
  */
 export async function readInput(filePath: string): Promise<string> {
   if (filePath === '-') {
-    // Read from stdin
     const chunks: Buffer[] = [];
     for await (const chunk of process.stdin) {
       chunks.push(chunk as Buffer);
@@ -31,13 +38,7 @@ export async function readInput(filePath: string): Promise<string> {
   try {
     return readFileSync(filePath, 'utf-8');
   } catch (error) {
-    console.error(JSON.stringify({
-      error: 'FILE_READ_ERROR',
-      message: error instanceof Error ? error.message : String(error),
-      path: filePath,
-    }));
-    process.exitCode = 2;
-    throw error; // bubbles up, but process will exit with code 2 if uncaught
+    throw new FileReadError(filePath, error);
   }
 }
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -20,6 +20,17 @@ export class FileReadError extends Error {
     super(cause instanceof Error ? cause.message : String(cause), { cause });
     this.name = 'FileReadError';
   }
+
+  get friendlyMessage(): string {
+    const errCode = (this.cause as { code?: string })?.code;
+    if (errCode === 'ENOENT') {
+      return `"${this.filePath}" not found. Create a DESIGN.md file or pass "-" to read from stdin.`;
+    }
+    if (errCode === 'EACCES') {
+      return `"${this.filePath}" could not be read: permission denied.`;
+    }
+    return `"${this.filePath}" could not be read: ${this.message}`;
+  }
 }
 
 /**


### PR DESCRIPTION
  fix(cli): graceful error on missing or unreadable input file

  ##Before
  ERROR ENOENT: no such file or directory, open 'DESIGN.md'
      at readFileSync (node:fs:441:20)
      at readInput (...index.js:24123:12)

 ##After

 File missing:
  Error: "DESIGN.md" not found. Create a DESIGN.md file or pass "-" to read from stdin.

 Permission denied:
  Error: "DESIGN.md" could not be read: permission denied.

  Any other I/O error:
  Error: "DESIGN.md" could not be read: <OS message>

  ##Solution

  Introduces a typed FileReadError class. readInput now throws it instead of calling process.exit directly. A friendlyMessage getter on the class checks the underlying OS error code
  (ENOENT, EACCES, etc.) to produce an accurate message — so the error never says "not found" when the real problem is permissions.

  Each command catches FileReadError, writes the plain-text message to stderr, and exits with code 2.

  ##Why this approach is better than a plain process.exit wrap:
  - readInput is unit-testable without mocking process.exit
  - FileReadError.filePath pinpoints which file failed (matters for diff, which reads two files)
  - FileReadError.friendlyMessage centralises message logic in one place — commands stay clean
  - Exit-code policy stays in the command layer where it belongs

  ##Changes
  - utils.ts — FileReadError class with friendlyMessage getter + readInput throws instead of exits
  - utils.test.ts — 6 new tests for readInput and FileReadError, zero mocking required
  - commands/lint.ts, commands/diff.ts, commands/export.ts — catch FileReadError, write error.friendlyMessage to stderr, exit code 2

  Fixes #132