### PR TITLE
fix(stdin): show TTY hint when reading from interactive terminal

### DIFF
--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, spyOn } from 'bun:test';
 import { readInput, FileReadError, formatOutput } from './utils.js';
+import type { StdinStream } from './utils.js';
+
+function makeStdin(content: string, isTTY: boolean): StdinStream {
+  async function* gen() { yield Buffer.from(content); }
+  return Object.assign(gen(), { isTTY });
+}
 
 describe('readInput', () => {
   it('throws FileReadError when file does not exist', async () => {
@@ -47,6 +53,41 @@ describe('readInput', () => {
     const cause = Object.assign(new Error('ENOMEM: out of memory'), { code: 'ENOMEM' });
     const err = new FileReadError('/some/file.md', cause);
     expect(err.friendlyMessage).toContain('ENOMEM');
+  });
+});
+
+describe('readInput stdin ("-")', () => {
+  it('reads content from a piped stream', async () => {
+    const result = await readInput('-', makeStdin('hello world', false));
+    expect(result).toBe('hello world');
+  });
+
+  it('returns empty string for an empty piped stream', async () => {
+    async function* empty() {}
+    const result = await readInput('-', Object.assign(empty(), { isTTY: false }));
+    expect(result).toBe('');
+  });
+
+  it('writes a hint to stderr when stdin is a TTY', async () => {
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      await readInput('-', makeStdin('some content', true));
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Press Ctrl+D')
+      );
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('does not write a hint when stdin is not a TTY', async () => {
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      await readInput('-', makeStdin('piped content', false));
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -14,6 +14,8 @@
 
 import { readFileSync } from 'node:fs';
 
+export type StdinStream = AsyncIterable<Buffer | string> & { isTTY?: boolean };
+
 export class FileReadError extends Error {
   readonly code = 'FILE_READ_ERROR' as const;
   constructor(public readonly filePath: string, cause: unknown) {
@@ -37,11 +39,14 @@ export class FileReadError extends Error {
  * Read input from a file path or stdin ("-").
  * Throws FileReadError if the file cannot be read.
  */
-export async function readInput(filePath: string): Promise<string> {
+export async function readInput(filePath: string, stdin: StdinStream = process.stdin): Promise<string> {
   if (filePath === '-') {
+    if (stdin.isTTY) {
+      process.stderr.write('Reading from stdin… Press Ctrl+D when done.\n');
+    }
     const chunks: Buffer[] = [];
-    for await (const chunk of process.stdin) {
-      chunks.push(chunk as Buffer);
+    for await (const chunk of stdin) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
     }
     return Buffer.concat(chunks).toString('utf-8');
   }


### PR DESCRIPTION
## Problem

When a user runs a `design.md` command with `-` as the file path from an
interactive terminal, the process hangs silently with no output:

```sh
$ design.md lint -
█  ← cursor blocks here indefinitely
```

There is no indication that the tool is waiting for input, or that the user must press `Ctrl+D` to signal end-of-file. A user unfamiliar with this Unix convention has no feedback to distinguish a stalled process from one that is working correctly.

## Root Cause

`readInput` reads stdin via `for await (const chunk of process.stdin)` with no TTY detection. When stdin is an interactive terminal
(`process.stdin.isTTY === true`), the loop blocks until EOF — but nothing prompts the user to send one.

## Solution

Before entering the read loop, check whether stdin is a TTY and, if so, emit a one-line hint to `stderr`:

Piped usage is completely unaffected — `isTTY` is `false` for pipes, so the hint never appears and existing behavior is unchanged:

```sh
cat DESIGN.md | design.md lint -   # works exactly as before
```

## Design Decisions

- `readInput` now accepts an optional `stdin` stream parameter that defaults to `process.stdin`. All existing call sites remain  unchanged.
- The optional parameter makes the TTY code path fully unit-testable via injected mock streams, without any need to mock       globals.
- `StdinStream` is exported so test files can type mock streams without duplicating the interface definition.

## Changes

| File | Change |
|---|---|
| `utils.ts` | Export `StdinStream` type; add optional `stdin` param to `readInput`; add TTY check before read loop |
| `utils.test.ts` | 4 new tests: piped content, empty stream, TTY hint emission, non-TTY silence — all using injected mock streams |