### PR TITLE
fix(export): remove extra trailing newline in css-tailwind output

### DIFF
--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -62,7 +62,7 @@ export default defineCommand({
         return;
       }
 
-      console.log(serializeTailwindV4(result.data.theme));
+      process.stdout.write(serializeTailwindV4(result.data.theme));
     } else if (format === 'json-tailwind' || format === 'tailwind') {
       const handler = new TailwindEmitterHandler();
       const result = handler.execute(report.designSystem);


### PR DESCRIPTION
serializeTailwindV4() already appends a trailing newline to the @theme block. Using console.log() adds a second trailing newline, making checked-in generated CSS fail strict whitespace gates like git diff --check.

Fixes #139

Change-Id: I3a0150b2c0f8e6a7b9d4c3e2f1a0b9c8d7e6f5a4