### PR TITLE
fix(export): set exit code 0 on a successful export

### DIFF
--- a/packages/cli/src/commands/export.test.ts
+++ b/packages/cli/src/commands/export.test.ts
@@ -66,7 +66,7 @@ describe('export command', () => {
     expect(logSpy.mock.calls.length).toBe(0);
     expect(errorSpy.mock.calls.length).toBe(1);
     const error = JSON.parse(errorSpy.mock.calls[0][0]);
-    expect(error.error).toContain('Invalid format "not-a-format"');
+    expect(error.message).toContain('Invalid format "not-a-format"');
     expect(process.exitCode).toBe(1);
   });
 });

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -118,5 +118,6 @@ export default defineCommand({
     // A successful export exits 0 even if the source has lint findings; those
     // are surfaced by `lint`, not by whether the export itself produced output.
     // The error branches above set a non-zero code and return before this point.
+    process.exitCode = 0;
   },
 });


### PR DESCRIPTION
The export success branches (css-tailwind, json-tailwind, dtcg, css-vars) write their output but never assign `process.exitCode`, so a successful run just leaves whatever value was already there rather than an explicit 0. This is the success-path counterpart to #126: that PR decoupled the exit code from source lint findings, but its subprocess test only covers json-tailwind, and a real process exits 0 when `exitCode` is unset, so the gap slipped through. I set `process.exitCode = 0` after the format branches (every error branch already returns first, so it only runs on success).

While confirming that, the in-process `export.test.ts` added in #109 turned out to be failing on main: it asserts `process.exitCode === 0` after a css-vars export, which was undefined. The same file also read `error.error` for the human-readable message, but the error envelope is `{ error: CODE, message: TEXT }`, so I pointed that one assertion at `error.message`.

Verified with `bun test` in `packages/cli`: the two `export.test.ts` failures now pass and the full suite is green (308 pass, 1 skip, 0 fail), `bun run lint` clean. Happy to adjust if you'd rather split the test-assertion tweak out. Thanks!