### PR TITLE
feat: support axis-specific padding component sub-tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ components:
     backgroundColor: "{colors.tertiary-container}"
 ```
 
-Valid component properties: `backgroundColor`, `textColor`, `typography`, `rounded`, `padding`, `size`, `height`, `width`.
+Valid component properties: `backgroundColor`, `textColor`, `typography`, `rounded`, `padding`, `paddingX`, `paddingY`, `size`, `height`, `width`.
 
 Variants (hover, active, pressed) are expressed as separate component entries with a related key name.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -336,6 +336,8 @@ Each component has a set of properties that are themselves design tokens:
 - typography: \<Typography\>
 - rounded: \<Dimension\>
 - padding: \<Dimension\>
+- paddingX: \<Dimension\>
+- paddingY: \<Dimension\>
 - size: \<Dimension\>
 - height: \<Dimension\>
 - width: \<Dimension\>

--- a/packages/cli/src/linter/linter/rules/broken-ref.test.ts
+++ b/packages/cli/src/linter/linter/rules/broken-ref.test.ts
@@ -46,6 +46,16 @@ describe('brokenRef', () => {
     expect(subTokenDiag!.severity).toBe('warning');
   });
 
+  it('does not emit warning for paddingX and paddingY sub-tokens', () => {
+    const state = buildState({
+      colors: { primary: '#ff0000' },
+      components: { button: { paddingX: '12px', paddingY: '16px' } },
+    });
+    const findings = brokenRef(state);
+    const subTokenDiag = findings.filter(d => d.message.includes('not a recognized'));
+    expect(subTokenDiag.length).toBe(0);
+  });
+
   it('has a valid rule descriptor', () => {
     expect(brokenRefRule.name).toBe('broken-ref');
     expect(brokenRefRule.severity).toBe('error');

--- a/packages/cli/src/linter/spec-config.yaml
+++ b/packages/cli/src/linter/spec-config.yaml
@@ -93,6 +93,10 @@ component_sub_tokens:
     type: Dimension
   - name: padding
     type: Dimension
+  - name: paddingX
+    type: Dimension
+  - name: paddingY
+    type: Dimension
   - name: size
     type: Dimension
   - name: height


### PR DESCRIPTION
Implemented support for axis-specific padding properties (`paddingX` and `paddingY`) inside component token definitions (resolves Issue #160).

## Background & Motivation
By default, the linter and spec support a uniform `padding` sub-token for components. However, asymmetric layouts (e.g., text inputs with different vertical and horizontal offsets) are standard in production design systems. Adding `paddingX` and `paddingY` addresses this capability gap natively.

*   This matches common framework layout models (Tailwind's `px`/`py`, SwiftUI, Flutter) and avoids nested layout mess (such as the very helpful schema formats discussed in #Issue #17).
*   This aligns with the philosophy of PR #89 (avoiding CSS property bloat like `paddingLeft`/`paddingTop`) by introducing structural layout minimums rather than exhaustive box-model properties.
*   Sourced independently from PR #164 to prevent merge conflicts.

## Changes
*   **Configuration**:
    *   Add `paddingX` and `paddingY` to the recognized `component_sub_tokens` schema list in `spec-config.yaml`.
*   **Test Coverage**:
    *   Add validation tests in `broken-ref.test.ts` verifying that component definitions containing `paddingX` and `paddingY` do not emit unrecognized sub-token warnings.
*   **Documentation**:
    *   Update the valid component properties list in `README.md`.
    *   Regenerate `docs/spec.md` using the spec compiler.