### PR TITLE
fix(cli): package spec for CLI command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bun build src/index.ts src/linter/index.ts --outdir dist --target node && npx tsc --project tsconfig.build.json --emitDeclarationOnly --skipLibCheck && cp src/linter/spec-config.yaml dist/linter/ && cp src/linter/spec-config.yaml dist/ && cp ../../docs/spec.md dist/linter/",
+    "build": "bun build src/index.ts src/linter/index.ts --outdir dist --target node && npx tsc --project tsconfig.build.json --emitDeclarationOnly --skipLibCheck && cp src/linter/spec-config.yaml dist/linter/ && cp src/linter/spec-config.yaml dist/ && cp ../../docs/spec.md dist/linter/ && cp ../../docs/spec.md dist/",
     "dev": "bun run src/index.ts",
     "test": "bun test",
     "lint": "tsc --noEmit --skipLibCheck",


### PR DESCRIPTION
Fixes #153.

## What changed

Copy `docs/spec.md` to both bundle entry-point directories during the CLI build. The linter entry point continues to resolve `dist/linter/spec.md`, while the CLI entry point can now resolve `dist/spec.md` as expected by `getSpecContent()`.

## Verification

- Reproduced the failure on `main`: package check #20 reported `CLI spec command failed to load spec.md`.
- `bun run check-package` — 25 passed, 0 failed.
- `bun test` — 282 passed, 1 skipped, 0 failed.
- `bun run lint` — passed.
- `git diff --check` — passed.

This PR does not change `.github/workflows`. Org-level zizmor can still fail on pre-existing unpinned actions in `test.yml`; that is outside the scope of #153.